### PR TITLE
fix: Update GitHub Actions workflows to properly handle Yarn 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,23 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'yarn'
     
     - name: Enable Corepack
       run: corepack enable
+    
+    - name: Set Yarn Version
+      run: corepack prepare yarn@4.6.0 --activate
+    
+    - name: Cache Yarn Dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          .yarn/cache
+          node_modules
+          */*/node_modules
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
       
     - name: Install dependencies
       run: yarn install --immutable

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,10 +35,23 @@ jobs:
         with:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org/'
-          cache: 'yarn'
       
       - name: Enable Corepack
         run: corepack enable
+      
+      - name: Set Yarn Version
+        run: corepack prepare yarn@4.6.0 --activate
+      
+      - name: Cache Yarn Dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            .yarn/cache
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       
       - name: Install Dependencies
         run: yarn install --immutable

--- a/.github/workflows/smithery.yml
+++ b/.github/workflows/smithery.yml
@@ -30,16 +30,29 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: '18'
-        cache: 'yarn'
     
     - name: Enable Corepack
       run: corepack enable
+    
+    - name: Set Yarn Version
+      run: corepack prepare yarn@4.6.0 --activate
+    
+    - name: Cache Yarn Dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          .yarn/cache
+          node_modules
+          */*/node_modules
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
     
     - name: Install dependencies
       run: yarn install --immutable
     
     - name: Install Smithery CLI
-      run: yarn global add @smithery/cli
+      run: npm install -g @smithery/cli
     
     - name: Login to Smithery
       run: smithery login


### PR DESCRIPTION
- Removed built-in cache: 'yarn' which doesn't work with Yarn 4
- Added explicit corepack prepare yarn@4.6.0 --activate step to set correct version
- Implemented proper cache configuration with actions/cache@v3
- Fixed Smithery CLI installation to use npm for global installs

🤖 Generated with [Claude Code](https://claude.ai/code)