### PR TITLE
Fix tsconfig paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "workspaces": [
-    "packages/*"
+    "servers/*"
   ],
   "scripts": {
     "build": "turbo run build",

--- a/servers/server-google-styleguide/tsconfig.json
+++ b/servers/server-google-styleguide/tsconfig.json
@@ -6,5 +6,5 @@
       "moduleResolution": "NodeNext",
       "module": "NodeNext"
     },
-    "files": ["./src/index.ts"]
+    "files": ["./index.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,18 +12,15 @@
     "declaration": true,
     "resolveJsonModule": true
   },
-  "include": [
-    "index.ts"
-  ],
+  "include": [],
   "exclude": [
     "node_modules",
     "dist"
   ],
   "references": [
-    { "path": "./packages/common" },
-    { "path": "./packages/server-yelp-fusionai" },
-    { "path": "./packages/server-stochasticthinking" },
-    { "path": "./packages/server-clear-thought" },
-    { "path": "./packages/server-google-styleguide" }
+    { "path": "./servers/server-stochasticthinking" },
+    { "path": "./servers/server-clear-thought" },
+    { "path": "./servers/server-google-styleguide" },
+    { "path": "./servers/server-typestyle" }
   ]
 }


### PR DESCRIPTION
## Summary
- fix workspace references in package.json
- update tsconfig references for actual server locations
- correct path in server-google-styleguide tsconfig

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_685586f7481c832580ed703d27ebf4ae