### PR TITLE
Fix CI install step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-yarn-
       
-    - name: Install dependencies
-      run: yarn install --mode=update-lockfile
+      - name: Install dependencies
+        run: yarn install --immutable
     
     - name: Build
       run: yarn build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
             ${{ runner.os }}-yarn-
       
       - name: Install Dependencies
-        run: yarn install --mode=update-lockfile
+        run: yarn install --immutable
       
       - name: Run tests
         run: yarn test

--- a/.github/workflows/smithery.yml
+++ b/.github/workflows/smithery.yml
@@ -49,7 +49,7 @@ jobs:
           ${{ runner.os }}-yarn-
     
     - name: Install dependencies
-      run: yarn install --mode=update-lockfile
+      run: yarn install --immutable
     
     - name: Install Smithery CLI
       run: npm install -g @smithery/cli


### PR DESCRIPTION
## Summary
- run `yarn install --immutable` in CI/CD workflows so node_modules are generated

## Testing
- `yarn build` *(fails: package doesn't seem to be present in lockfile)*
- `yarn test` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6855da265ac8832592ebc7bfbd7da199