### PR TITLE
Add plan for clear-thought toolset refactor

### DIFF
--- a/servers/server-clear-thought/TOOLSET_REFACTOR_PLAN.md
+++ b/servers/server-clear-thought/TOOLSET_REFACTOR_PLAN.md
@@ -1,0 +1,76 @@
+# Clear Thought Toolset Refactor Plan
+
+## Background
+
+The Clear Thought MCP server currently exposes every thinking capability as a separate MCP tool. The file [`src/tools/index.ts`](src/tools/index.ts) lists more than twenty `register...` functions that each register an individual tool with the server. This produces a very large tool list for the client model to reason about.
+
+Example excerpt:
+```ts
+import { registerSequentialThinking } from './sequential-thinking.js';
+import { registerMentalModel } from './mental-model.js';
+import { registerDebuggingApproach } from './debugging-approach.js';
+import { registerCollaborativeReasoning } from './collaborative-reasoning.js';
+import { registerDecisionFramework } from './decision-framework.js';
+import { registerMetacognitiveMonitoring } from './metacognitive.js';
+import { registerSocraticMethod } from './socratic-method.js';
+import { registerCreativeThinking } from './creative-thinking.js';
+import { registerSystemsThinking } from './systems-thinking.js';
+import { registerScientificMethod } from './scientific-method.js';
+import { registerStructuredArgumentation } from './structured-argumentation.js';
+import { registerVisualReasoning } from './visual-reasoning.js';
+import { registerAnalogicalMapper } from './analogical-mapper.js';
+import { registerAssumptionXray } from './assumption-xray.js';
+import { registerComparativeAdvantage } from './comparative-advantage.js';
+```
+
+Each tool module follows the pattern below (from [`src/tools/mental-model.ts`](src/tools/mental-model.ts)):
+```ts
+export function registerMentalModel(server: McpServer, sessionState: SessionState) {
+  server.tool(
+    'mentalmodel',
+    'Apply mental models to analyze problems systematically',
+    {
+      modelName: z.enum(['first_principles', 'opportunity_cost', 'error_propagation', 'rubber_duck', 'pareto_principle', 'occams_razor']).describe('Name of the mental model'),
+      problem: z.string().describe('The problem being analyzed'),
+      steps: z.array(z.string()).describe('Steps to apply the model'),
+      reasoning: z.string().describe('Reasoning process'),
+      conclusion: z.string().describe('Conclusions drawn')
+    },
+    async (args) => {
+      const modelData: MentalModelData = {
+        modelName: args.modelName,
+        problem: args.problem,
+        steps: args.steps,
+        reasoning: args.reasoning,
+        conclusion: args.conclusion
+      };
+      
+```
+
+## Goal
+
+Adopt the MCP "toolset" pattern used in the official Go server and in Waldzell AI's Exa Websets server. Related operations are grouped under a single tool which declares an `operation` field. An internal registry dispatches calls to the appropriate handler. This reduces the number of top level tools and lowers cognitive overhead for the model.
+
+## Proposed Toolsets
+
+- **reasoning** – sequential thinking, mental models, debugging approaches, collaborative reasoning, decision frameworks, metacognitive monitoring, scientific method, creative thinking, systems thinking, structured argumentation, etc.
+- **visualization** – mind map, concept map, fishbone diagram, SWOT analysis, issue tree, visual reasoning and other diagram oriented helpers.
+- **utility** – analogical mapper, assumption x‑ray, comparative advantage, drag point audit, safe struggle designer, seven seekers orchestrator, value of information and other stand‑alone helpers.
+- **session** – session info, export and import.
+
+Each toolset will expose one MCP tool containing an `operation` parameter which selects among the above operations.
+
+## Implementation Steps
+
+1. **Create a `ToolsetRegistry` class** that allows registering operations with a name, zod schema and handler. The registry exposes a method to construct the combined MCP tool schema using a discriminated union over the registered operations.
+2. **Refactor individual tools** into operation functions returning `{schema, handler}` pairs. Migrate the logic from each `register*` function.
+3. **Define toolset modules** (`reasoning.ts`, `visualization.ts`, `utility.ts`, `session.ts`). Each module creates a registry, adds its operations and finally calls `server.tool` once with the aggregated schema and dispatcher.
+4. **Update `registerTools`** to register the four new toolsets instead of the many individual tools.
+5. **Adjust session state access** so each operation still interacts with `SessionState` as today. No functional behaviour should change besides the tool entry points.
+6. **Update tests and examples** to call the new toolsets via the `operation` field rather than the old tool names.
+
+## Benefits
+
+- The MCP client sees only a few high level tools, reducing prompt length and reasoning complexity.
+- Related operations share schemas and code paths, improving maintainability.
+- New operations can be added easily by extending the appropriate registry.

--- a/servers/server-clear-thought/src/tools/index.ts
+++ b/servers/server-clear-thought/src/tools/index.ts
@@ -1,66 +1,19 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { SessionState } from '../state/SessionState.js';
 
-import { registerSequentialThinking } from './sequential-thinking.js';
-import { registerMentalModel } from './mental-model.js';
-import { registerDebuggingApproach } from './debugging-approach.js';
-import { registerCollaborativeReasoning } from './collaborative-reasoning.js';
-import { registerDecisionFramework } from './decision-framework.js';
-import { registerMetacognitiveMonitoring } from './metacognitive.js';
-import { registerSocraticMethod } from './socratic-method.js';
-import { registerCreativeThinking } from './creative-thinking.js';
-import { registerSystemsThinking } from './systems-thinking.js';
-import { registerScientificMethod } from './scientific-method.js';
-import { registerStructuredArgumentation } from './structured-argumentation.js';
-import { registerVisualReasoning } from './visual-reasoning.js';
-import { registerAnalogicalMapper } from './analogical-mapper.js';
-import { registerAssumptionXray } from './assumption-xray.js';
-import { registerComparativeAdvantage } from './comparative-advantage.js';
-import { registerDragPointAudit } from './drag-point-audit.js';
-import { registerSafeStruggleDesigner } from './safe-struggle-designer.js';
-import { registerSevenSeekersOrchestrator } from './seven-seekers-orchestrator.js';
-import { registerValueOfInformation } from './value-of-information.js';
-import { registerExistingToolExample } from './existing-tool-example.js';
-import { registerMindMap } from './mind-map.js';
-import { registerConceptMap } from './concept-map.js';
-import { registerFishboneDiagram } from './fishbone-diagram.js';
-import { registerSwotAnalysis } from './swot-analysis.js';
-import { registerIssueTree } from './issue-tree.js';
-import { registerSessionManagement } from './session-management.js';
+import { registerReasoningToolset } from '../toolsets/reasoning.js';
+import { registerVisualizationToolset } from '../toolsets/visualization.js';
+import { registerUtilityToolset } from '../toolsets/utility.js';
+import { registerSessionToolset } from '../toolsets/session.js';
 
 /**
- * Registers all Clear Thought tools with the provided MCP server instance
+ * Registers all Clear Thought toolsets with the provided MCP server instance
  * @param server - The MCP server instance
  * @param sessionState - The session state manager
  */
 export function registerTools(server: McpServer, sessionState: SessionState): void {
-  // Register all thinking and reasoning tools
-  registerSequentialThinking(server, sessionState);
-  registerMentalModel(server, sessionState);
-  registerDebuggingApproach(server, sessionState);
-  registerCollaborativeReasoning(server, sessionState);
-  registerDecisionFramework(server, sessionState);
-  registerMetacognitiveMonitoring(server, sessionState);
-  registerSocraticMethod(server, sessionState);
-  registerCreativeThinking(server, sessionState);
-  registerSystemsThinking(server, sessionState);
-  registerScientificMethod(server, sessionState);
-  registerStructuredArgumentation(server, sessionState);
-  registerVisualReasoning(server, sessionState);
-  registerAnalogicalMapper(server, sessionState);
-  registerAssumptionXray(server, sessionState);
-  registerComparativeAdvantage(server, sessionState);
-  registerDragPointAudit(server, sessionState);
-  registerSafeStruggleDesigner(server, sessionState);
-  registerSevenSeekersOrchestrator(server, sessionState);
-  registerValueOfInformation(server, sessionState);
-  registerMindMap(server, sessionState);
-  registerConceptMap(server, sessionState);
-  registerFishboneDiagram(server, sessionState);
-  registerSwotAnalysis(server, sessionState);
-  registerIssueTree(server, sessionState);
-  registerExistingToolExample(server, sessionState);
-
-  // Register session management tools
-  registerSessionManagement(server, sessionState);
+  registerReasoningToolset(server, sessionState);
+  registerVisualizationToolset(server, sessionState);
+  registerUtilityToolset(server, sessionState);
+  registerSessionToolset(server, sessionState);
 }

--- a/servers/server-clear-thought/src/toolsets/reasoning.ts
+++ b/servers/server-clear-thought/src/toolsets/reasoning.ts
@@ -1,0 +1,35 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { SessionState } from '../state/SessionState.js';
+import { ToolsetRegistry, collectOperations } from './registry.js';
+
+import { registerSequentialThinking } from '../tools/sequential-thinking.js';
+import { registerMentalModel } from '../tools/mental-model.js';
+import { registerDebuggingApproach } from '../tools/debugging-approach.js';
+import { registerCollaborativeReasoning } from '../tools/collaborative-reasoning.js';
+import { registerDecisionFramework } from '../tools/decision-framework.js';
+import { registerMetacognitiveMonitoring } from '../tools/metacognitive.js';
+import { registerSocraticMethod } from '../tools/socratic-method.js';
+import { registerCreativeThinking } from '../tools/creative-thinking.js';
+import { registerSystemsThinking } from '../tools/systems-thinking.js';
+import { registerScientificMethod } from '../tools/scientific-method.js';
+import { registerStructuredArgumentation } from '../tools/structured-argumentation.js';
+
+export function registerReasoningToolset(server: McpServer, state: SessionState): void {
+  const registry = new ToolsetRegistry('reasoning', 'Reasoning operations');
+  [
+    registerSequentialThinking,
+    registerMentalModel,
+    registerDebuggingApproach,
+    registerCollaborativeReasoning,
+    registerDecisionFramework,
+    registerMetacognitiveMonitoring,
+    registerSocraticMethod,
+    registerCreativeThinking,
+    registerSystemsThinking,
+    registerScientificMethod,
+    registerStructuredArgumentation
+  ].forEach(fn => {
+    collectOperations(fn, state).forEach(op => registry.addOperation(op));
+  });
+  registry.register(server);
+}

--- a/servers/server-clear-thought/src/toolsets/registry.ts
+++ b/servers/server-clear-thought/src/toolsets/registry.ts
@@ -1,0 +1,47 @@
+import { z, ZodTypeAny } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export interface OperationSpec {
+  name: string;
+  description: string;
+  schema: Record<string, ZodTypeAny>;
+  handler: (args: any) => Promise<any>;
+}
+
+export class ToolsetRegistry {
+  private operations: OperationSpec[] = [];
+
+  constructor(private slug: string, private description: string) {}
+
+  addOperation(op: OperationSpec): void {
+    this.operations.push(op);
+  }
+
+  register(server: McpServer): void {
+    if (this.operations.length === 0) return;
+    const schemas = this.operations.map((op) =>
+      z.object({ operation: z.literal(op.name), ...op.schema })
+    );
+    const schema = z.union(schemas as [z.ZodTypeAny, ...z.ZodTypeAny[]]);
+    const dispatcher = async (args: any) => {
+      const op = this.operations.find((o) => o.name === args.operation);
+      if (!op) throw new Error(`Unknown operation: ${args.operation}`);
+      return op.handler(args);
+    };
+    server.tool(this.slug, this.description, schema, dispatcher);
+  }
+}
+
+export function collectOperations(
+  registerFn: (server: McpServer, state: any) => void,
+  state: any
+): OperationSpec[] {
+  const ops: OperationSpec[] = [];
+  const fakeServer = {
+    tool(name: string, description: string, schema: any, handler: any) {
+      ops.push({ name, description, schema, handler });
+    }
+  } as unknown as McpServer;
+  registerFn(fakeServer, state);
+  return ops;
+}

--- a/servers/server-clear-thought/src/toolsets/session.ts
+++ b/servers/server-clear-thought/src/toolsets/session.ts
@@ -1,0 +1,11 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { SessionState } from '../state/SessionState.js';
+import { ToolsetRegistry, collectOperations } from './registry.js';
+
+import { registerSessionManagement } from '../tools/session-management.js';
+
+export function registerSessionToolset(server: McpServer, state: SessionState): void {
+  const registry = new ToolsetRegistry('session', 'Session management operations');
+  collectOperations(registerSessionManagement, state).forEach(op => registry.addOperation(op));
+  registry.register(server);
+}

--- a/servers/server-clear-thought/src/toolsets/utility.ts
+++ b/servers/server-clear-thought/src/toolsets/utility.ts
@@ -1,0 +1,29 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { SessionState } from '../state/SessionState.js';
+import { ToolsetRegistry, collectOperations } from './registry.js';
+
+import { registerAnalogicalMapper } from '../tools/analogical-mapper.js';
+import { registerAssumptionXray } from '../tools/assumption-xray.js';
+import { registerComparativeAdvantage } from '../tools/comparative-advantage.js';
+import { registerDragPointAudit } from '../tools/drag-point-audit.js';
+import { registerSafeStruggleDesigner } from '../tools/safe-struggle-designer.js';
+import { registerSevenSeekersOrchestrator } from '../tools/seven-seekers-orchestrator.js';
+import { registerValueOfInformation } from '../tools/value-of-information.js';
+import { registerExistingToolExample } from '../tools/existing-tool-example.js';
+
+export function registerUtilityToolset(server: McpServer, state: SessionState): void {
+  const registry = new ToolsetRegistry('utility', 'Utility operations');
+  [
+    registerAnalogicalMapper,
+    registerAssumptionXray,
+    registerComparativeAdvantage,
+    registerDragPointAudit,
+    registerSafeStruggleDesigner,
+    registerSevenSeekersOrchestrator,
+    registerValueOfInformation,
+    registerExistingToolExample
+  ].forEach(fn => {
+    collectOperations(fn, state).forEach(op => registry.addOperation(op));
+  });
+  registry.register(server);
+}

--- a/servers/server-clear-thought/src/toolsets/visualization.ts
+++ b/servers/server-clear-thought/src/toolsets/visualization.ts
@@ -1,0 +1,25 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { SessionState } from '../state/SessionState.js';
+import { ToolsetRegistry, collectOperations } from './registry.js';
+
+import { registerMindMap } from '../tools/mind-map.js';
+import { registerConceptMap } from '../tools/concept-map.js';
+import { registerFishboneDiagram } from '../tools/fishbone-diagram.js';
+import { registerSwotAnalysis } from '../tools/swot-analysis.js';
+import { registerIssueTree } from '../tools/issue-tree.js';
+import { registerVisualReasoning } from '../tools/visual-reasoning.js';
+
+export function registerVisualizationToolset(server: McpServer, state: SessionState): void {
+  const registry = new ToolsetRegistry('visualization', 'Visualization operations');
+  [
+    registerMindMap,
+    registerConceptMap,
+    registerFishboneDiagram,
+    registerSwotAnalysis,
+    registerIssueTree,
+    registerVisualReasoning
+  ].forEach(fn => {
+    collectOperations(fn, state).forEach(op => registry.addOperation(op));
+  });
+  registry.register(server);
+}

--- a/servers/server-clear-thought/tests/existing-tool-example.test.ts
+++ b/servers/server-clear-thought/tests/existing-tool-example.test.ts
@@ -1,14 +1,14 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { defaultConfig } from '../src/config.js';
 import { SessionState } from '../src/state/SessionState.js';
-import { registerExistingToolExample } from '../src/tools/existing-tool-example.js';
+import { registerUtilityToolset } from '../src/toolsets/utility.js';
 
 it('echoes provided text', async () => {
   const server = new McpServer({ name: 'test', version: '0.0.0' });
   const state = new SessionState('test', defaultConfig);
-  registerExistingToolExample(server, state);
-  const tool: any = (server as any)._registeredTools['existing_tool_example'];
-  const result = await tool.callback({ text: 'hi' });
+  registerUtilityToolset(server, state);
+  const tool: any = (server as any)._registeredTools['utility'];
+  const result = await tool.callback({ operation: 'existing_tool_example', text: 'hi' });
   const data = JSON.parse(result.content[0].text);
   expect(data).toEqual({ echoed: 'hi' });
 });

--- a/servers/server-clear-thought/tests/mind-map.test.ts
+++ b/servers/server-clear-thought/tests/mind-map.test.ts
@@ -1,14 +1,13 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { defaultConfig } from '../src/config.js';
 import { SessionState } from '../src/state/SessionState.js';
-import { registerMindMap } from '../src/tools/mind-map.js';
+import { registerVisualizationToolset } from '../src/toolsets/visualization.js';
 
 it('generates branches from a topic', async () => {
   const server = new McpServer({ name: 'test', version: '0.0.0' });
   const state = new SessionState('test', defaultConfig);
-  registerMindMap(server, state);
-  // Access the registered tool (private API)
-  const tool: any = (server as any)._registeredTools['mind_map'];
-  const result = await tool.callback({ topic: 'cats', num_branches: 2 });
+  registerVisualizationToolset(server, state);
+  const tool: any = (server as any)._registeredTools['visualization'];
+  const result = await tool.callback({ operation: 'mind_map', topic: 'cats', num_branches: 2 });
   expect(result.content[0].text).toContain('cats aspect');
 });

--- a/servers/server-clear-thought/tests/new-tools.test.ts
+++ b/servers/server-clear-thought/tests/new-tools.test.ts
@@ -1,13 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { defaultConfig } from '../src/config.js';
 import { SessionState } from '../src/state/SessionState.js';
-import { registerAssumptionXray } from '../src/tools/assumption-xray.js';
-import { registerValueOfInformation } from '../src/tools/value-of-information.js';
-import { registerDragPointAudit } from '../src/tools/drag-point-audit.js';
-import { registerSafeStruggleDesigner } from '../src/tools/safe-struggle-designer.js';
-import { registerComparativeAdvantage } from '../src/tools/comparative-advantage.js';
-import { registerAnalogicalMapper } from '../src/tools/analogical-mapper.js';
-import { registerSevenSeekersOrchestrator } from '../src/tools/seven-seekers-orchestrator.js';
+import { registerUtilityToolset } from '../src/toolsets/utility.js';
 
 function setupServer() {
   const server = new McpServer({ name: 'test', version: '0.0.0' });
@@ -17,69 +11,69 @@ function setupServer() {
 
 type ToolCallback = (args: any) => Promise<any>;
 
-function getCallback(server: McpServer, slug: string): ToolCallback {
-  return (server as any)._registeredTools[slug].callback;
+function getCallback(server: McpServer): ToolCallback {
+  return (server as any)._registeredTools['utility'].callback;
 }
 
 it('assumption xray returns assumptions, confidence and tests', async () => {
   const { server, state } = setupServer();
-  registerAssumptionXray(server, state);
-  const cb = getCallback(server, 'assumption_xray');
-  const result = await cb({ claim: 'A', context: 'B' });
+  registerUtilityToolset(server, state);
+  const cb = getCallback(server);
+  const result = await cb({ operation: 'assumption_xray', claim: 'A', context: 'B' });
   const data = JSON.parse(result.content[0].text);
   expect(Object.keys(data)).toEqual(['assumptions', 'confidence', 'tests']);
 });
 
 it('value of information returns score and questions', async () => {
   const { server, state } = setupServer();
-  registerValueOfInformation(server, state);
-  const cb = getCallback(server, 'value_of_information');
-  const result = await cb({ decision_options: ['a'], uncertainties: ['u'], payoffs: [1] });
+  registerUtilityToolset(server, state);
+  const cb = getCallback(server);
+  const result = await cb({ operation: 'value_of_information', decision_options: ['a'], uncertainties: ['u'], payoffs: [1] });
   const data = JSON.parse(result.content[0].text);
   expect(Object.keys(data)).toEqual(['voi_score', 'high_impact_questions']);
 });
 
 it('drag point audit returns drag points and summary score', async () => {
   const { server, state } = setupServer();
-  registerDragPointAudit(server, state);
-  const cb = getCallback(server, 'drag_point_audit');
-  const result = await cb({ log: '...' });
+  registerUtilityToolset(server, state);
+  const cb = getCallback(server);
+  const result = await cb({ operation: 'drag_point_audit', log: '...' });
   const data = JSON.parse(result.content[0].text);
   expect(Object.keys(data)).toEqual(['drag_points', 'summary_score']);
 });
 
 it('safe struggle designer returns steps, measures and intervals', async () => {
   const { server, state } = setupServer();
-  registerSafeStruggleDesigner(server, state);
-  const cb = getCallback(server, 'safe_struggle_designer');
-  const result = await cb({ skill: 'x', current_level: 1, target_level: 2 });
+  registerUtilityToolset(server, state);
+  const cb = getCallback(server);
+  const result = await cb({ operation: 'safe_struggle_designer', skill: 'x', current_level: 1, target_level: 2 });
   const data = JSON.parse(result.content[0].text);
   expect(Object.keys(data)).toEqual(['scaffold_steps', 'safety_measures', 'review_intervals']);
 });
 
 it('comparative advantage returns advantage map', async () => {
   const { server, state } = setupServer();
-  registerComparativeAdvantage(server, state);
-  const cb = getCallback(server, 'comparative_advantage');
-  const result = await cb({ skills: { a: 1 }, tasks: { t1: ['a'] } });
+  registerUtilityToolset(server, state);
+  const cb = getCallback(server);
+  const result = await cb({ operation: 'comparative_advantage', skills: { a: 1 }, tasks: { t1: ['a'] } });
   const data = JSON.parse(result.content[0].text);
   expect(Object.keys(data)).toEqual(['advantage_map']);
 });
 
 it('analogical mapper returns analogies and prompts', async () => {
   const { server, state } = setupServer();
-  registerAnalogicalMapper(server, state);
-  const cb = getCallback(server, 'analogical_mapper');
-  const result = await cb({ problem: 'p' });
+  registerUtilityToolset(server, state);
+  const cb = getCallback(server);
+  const result = await cb({ operation: 'analogical_mapper', problem: 'p' });
   const data = JSON.parse(result.content[0].text);
   expect(Object.keys(data)).toEqual(['analogies', 'suggested_prompts']);
 });
 
 it('seven seekers orchestrator returns results, resonance and synthesis', async () => {
   const { server, state } = setupServer();
-  registerSevenSeekersOrchestrator(server, state);
-  const cb = getCallback(server, 'seven_seekers_orchestrator');
-  const result = await cb({ query: 'q' });
+  registerUtilityToolset(server, state);
+  const cb = getCallback(server);
+  const result = await cb({ operation: 'seven_seekers_orchestrator', query: 'q' });
   const data = JSON.parse(result.content[0].text);
   expect(Object.keys(data)).toEqual(['seeker_results', 'resonance_map', 'synthesis']);
 });


### PR DESCRIPTION
## Summary
- outline a plan to refactor the Clear Thought server to use the MCP toolset pattern
- implement ToolsetRegistry and new toolset modules
- update registerTools to expose the toolsets
- adapt tests to call the aggregated tools

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884d301f2dc8325a55aaae3fae76489