### PR TITLE
Implement Clear Thought toolset registry

### DIFF
--- a/servers/server-clear-thought/README.md
+++ b/servers/server-clear-thought/README.md
@@ -161,33 +161,36 @@ npx @waldzellai/clear-thought
 ### Mental Models
 
 ```typescript
-const response = await mcp.callTool('mentalmodel', {
+const response = await mcp.callTool('reasoning', {
+  operation: 'mentalmodel',
   modelName: 'first_principles',
   problem: 'How to implement a new feature?',
-  steps: ['Break down the problem', 'Analyze components', 'Build solution'],
+  steps: ['Break down the problem', 'Analyze components', 'Build solution']
 });
 ```
 
 ### Debugging Approaches
 
 ```typescript
-const response = await mcp.callTool('debuggingapproach', {
+const response = await mcp.callTool('reasoning', {
+  operation: 'debuggingapproach',
   approachName: 'binary_search',
   issue: 'Performance degradation in the system',
   steps: ['Identify performance metrics', 'Locate bottleneck', 'Implement solution'],
   findings: 'Database connections spiking during peak hours',
-  resolution: 'Optimized connection pooling',
+  resolution: 'Optimized connection pooling'
 });
 ```
 
 ### Sequential Thinking
 
 ```typescript
-const response = await mcp.callTool('sequentialthinking', {
+const response = await mcp.callTool('reasoning', {
+  operation: 'sequentialthinking',
   thought: 'Initial analysis of the problem',
   thoughtNumber: 1,
   totalThoughts: 3,
-  nextThoughtNeeded: true,
+  nextThoughtNeeded: true
 });
 ```
 

--- a/servers/server-clear-thought/src/toolsets/registry.ts
+++ b/servers/server-clear-thought/src/toolsets/registry.ts
@@ -22,13 +22,22 @@ export class ToolsetRegistry {
     const schemas = this.operations.map((op) =>
       z.object({ operation: z.literal(op.name), ...op.schema })
     );
-    const schema = z.union(schemas as [z.ZodTypeAny, ...z.ZodTypeAny[]]);
+    const schema =
+      schemas.length === 1
+        ? schemas[0]
+        : z.union(
+            [schemas[0], schemas[1], ...schemas.slice(2)] as [
+              z.ZodTypeAny,
+              z.ZodTypeAny,
+              ...z.ZodTypeAny[]
+            ]
+          );
     const dispatcher = async (args: any) => {
       const op = this.operations.find((o) => o.name === args.operation);
       if (!op) throw new Error(`Unknown operation: ${args.operation}`);
       return op.handler(args);
     };
-    server.tool(this.slug, this.description, schema, dispatcher);
+    server.tool(this.slug, this.description, schema as any, dispatcher);
   }
 }
 


### PR DESCRIPTION
## Summary
- refactor Clear Thought tool registration
- update examples to use the new `reasoning` toolset
- build a more flexible `ToolsetRegistry`

## Testing
- `npm test --workspaces --silent`

------
https://chatgpt.com/codex/tasks/task_e_6884d72a58688325988689b64c1fbabe