### PR TITLE
feat(yelp): add Yelp Fusion AI MCP server

### DIFF
--- a/servers/server-yelp-fusionai/README.md
+++ b/servers/server-yelp-fusionai/README.md
@@ -1,0 +1,243 @@
+# Yelp Fusion AI MCP Server
+
+An MCP (Model Context Protocol) server that wraps the Yelp Fusion API, exposing it as tools for LLM consumption. Implements the MCP 2025-11-25 protocol with Streamable HTTP transport.
+
+## Features
+
+- **Business Search**: Find businesses by location, category, and various filters
+- **Business Details**: Get comprehensive information about specific businesses
+- **Reviews**: Access reviews and highlighted snippets
+- **AI Chat**: Conversational interface to Yelp's AI for recommendations (with streaming support)
+- **Events**: Search for local events and activities
+- **Autocomplete**: Get search suggestions
+- **Categories**: Browse Yelp's business category taxonomy
+
+## Installation
+
+```bash
+npm install
+npm run build
+```
+
+## Configuration
+
+The server requires a Yelp Fusion API key. Get one at [Yelp Fusion](https://www.yelp.com/developers/v3/manage_app).
+
+```bash
+export YELP_API_KEY=your_api_key_here
+```
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `YELP_API_KEY` | Yelp Fusion API key (required) | - |
+| `PORT` | Server port | `3000` |
+| `HOST` | Server host | `0.0.0.0` |
+
+## Usage
+
+### Start the Server
+
+```bash
+# Development
+npm run dev
+
+# Production
+npm start
+```
+
+### Health Check
+
+```bash
+curl http://localhost:3000/health
+```
+
+### MCP Endpoint
+
+The server exposes an MCP endpoint at `/mcp` that accepts:
+- `POST /mcp` - Send MCP requests
+- `GET /mcp` - Establish SSE stream
+- `DELETE /mcp` - Terminate session
+
+### Claude Desktop Configuration
+
+Add to your Claude Desktop config:
+
+```json
+{
+  "mcpServers": {
+    "yelp": {
+      "command": "node",
+      "args": ["/path/to/server-yelp-fusionai/dist/index.js"],
+      "env": {
+        "YELP_API_KEY": "your_api_key_here"
+      }
+    }
+  }
+}
+```
+
+## Available Tools
+
+### Business Search
+
+| Tool | Description |
+|------|-------------|
+| `yelp_search` | Search businesses by location and term |
+| `yelp_phone_search` | Find business by phone number |
+| `yelp_business_match` | Match business by name/address |
+| `yelp_business_details` | Get full business details |
+
+### Reviews
+
+| Tool | Description |
+|------|-------------|
+| `yelp_reviews` | Get business reviews |
+| `yelp_review_highlights` | Get highlighted review snippets |
+
+### AI Chat
+
+| Tool | Description |
+|------|-------------|
+| `yelp_ai_chat` | Conversational AI for recommendations |
+| `yelp_ai_chat_stream` | Streaming AI chat responses |
+
+### Events
+
+| Tool | Description |
+|------|-------------|
+| `yelp_events` | Search for events |
+| `yelp_event_details` | Get event details |
+| `yelp_featured_event` | Get featured event for location |
+
+### Autocomplete
+
+| Tool | Description |
+|------|-------------|
+| `yelp_autocomplete` | Get search suggestions |
+
+### Categories
+
+| Tool | Description |
+|------|-------------|
+| `yelp_categories` | List all categories |
+| `yelp_category_details` | Get category details |
+
+### Transactions & Service Offerings
+
+| Tool | Description |
+|------|-------------|
+| `yelp_delivery_search` | Search businesses that support food delivery |
+| `yelp_service_offerings` | Get service offerings for a business (delivery, pickup, etc.) |
+
+### Business Insights
+
+| Tool | Description |
+|------|-------------|
+| `yelp_engagement_metrics` | Get engagement metrics (impressions, leads, calls) for businesses |
+| `yelp_business_insights` | Get business insights data |
+| `yelp_food_drinks_insights` | Get popular dishes and drinks for a business |
+| `yelp_risk_signals` | Get risk signal insights for a business |
+
+### Waitlist
+
+| Tool | Description |
+|------|-------------|
+| `yelp_waitlist_status` | Get waitlist status and wait estimates for a business |
+| `yelp_waitlist_info` | Get waitlist configuration and hours for a business |
+| `yelp_visit_details` | Get details of a specific waitlist visit |
+| `yelp_partner_restaurants` | Find restaurants with Yelp Waitlist support |
+
+### Reservations
+
+| Tool | Description |
+|------|-------------|
+| `yelp_reservation_openings` | Get available reservation times for a restaurant |
+| `yelp_reservation_status` | Get the status of a reservation |
+
+## Example Usage
+
+### Search for restaurants
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "yelp_search",
+    "arguments": {
+      "term": "sushi",
+      "location": "San Francisco, CA",
+      "sort_by": "rating",
+      "limit": 5
+    }
+  }
+}
+```
+
+### Get business reviews
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "yelp_reviews",
+    "arguments": {
+      "business_id": "north-india-restaurant-san-francisco",
+      "limit": 10
+    }
+  }
+}
+```
+
+### AI Chat
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "yelp_ai_chat",
+    "arguments": {
+      "query": "What's a good Italian restaurant for a date night in the Marina?",
+      "location": "San Francisco, CA"
+    }
+  }
+}
+```
+
+## Architecture
+
+```
+src/
+├── index.ts              # HTTP server entry point
+├── server-factory.ts     # MCP server configuration
+├── tools/
+│   ├── index.ts          # Tool registry
+│   ├── business.ts       # Business search/details tools
+│   ├── reviews.ts        # Reviews tools
+│   ├── ai-chat.ts        # AI Chat tool (streaming)
+│   ├── events.ts         # Events tools
+│   ├── autocomplete.ts   # Autocomplete tool
+│   └── categories.ts     # Categories tools
+└── yelp-client/
+    ├── index.ts          # Yelp API client
+    └── types.ts          # TypeScript types
+```
+
+## Development
+
+```bash
+# Watch mode
+npm run watch
+
+# Type checking
+npm run typecheck
+```
+
+## API Reference
+
+See the [Yelp Fusion API Documentation](https://docs.developer.yelp.com/docs/fusion-intro) for full API details.
+
+## License
+
+MIT

--- a/servers/server-yelp-fusionai/package.json
+++ b/servers/server-yelp-fusionai/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@waldzellai/yelp-fusionai",
+  "version": "0.1.0",
+  "description": "MCP server for Yelp Fusion API with AI Chat support",
+  "license": "MIT",
+  "author": "Waldzell AI",
+  "homepage": "https://github.com/waldzellai/waldzell-mcp/tree/main/servers/server-yelp-fusionai",
+  "bugs": {
+    "url": "https://github.com/waldzellai/waldzell-mcp/issues"
+  },
+  "type": "module",
+  "bin": {
+    "mcp-server-yelp-fusionai": "dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit",
+    "dev": "tsx src/index.ts",
+    "start": "node dist/index.js",
+    "watch": "tsc --watch",
+    "prebuild": "npm run clean"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/waldzellai/waldzell-mcp.git"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.24.3",
+    "express": "^5.1.0",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.5",
+    "@types/node": "^22.18.12",
+    "tsx": "^4.20.6",
+    "typescript": "^5.3.3"
+  },
+  "keywords": [
+    "mcp",
+    "yelp",
+    "fusion-api",
+    "ai-chat",
+    "business-search",
+    "reviews"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "main": "./dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js"
+    }
+  }
+}

--- a/servers/server-yelp-fusionai/src/index.ts
+++ b/servers/server-yelp-fusionai/src/index.ts
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+/**
+ * Yelp Fusion AI MCP Server - HTTP Entry Point
+ *
+ * Implements Streamable HTTP transport (MCP 2025-11-25 protocol)
+ */
+
+import crypto from 'node:crypto';
+import express, { type Request, type Response } from 'express';
+import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { createMcpServer } from './server-factory.js';
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+const YELP_API_KEY = process.env.YELP_API_KEY;
+const PORT = parseInt(process.env.PORT || '3000', 10);
+const HOST = process.env.HOST || '0.0.0.0';
+
+if (!YELP_API_KEY) {
+  console.error('ERROR: YELP_API_KEY environment variable is required');
+  process.exit(1);
+}
+
+// =============================================================================
+// HTTP Server
+// =============================================================================
+
+const app = createMcpExpressApp({
+  host: HOST,
+});
+
+interface SessionEntry {
+  transport: StreamableHTTPServerTransport;
+}
+
+const sessions = new Map<string, SessionEntry>();
+
+// =============================================================================
+// MCP Endpoint
+// =============================================================================
+
+app.all('/mcp', async (req: Request, res: Response) => {
+  const mcpSessionId = req.headers['mcp-session-id'] as string | undefined;
+
+  try {
+    // Check for existing session
+    if (mcpSessionId && sessions.has(mcpSessionId)) {
+      const entry = sessions.get(mcpSessionId)!;
+
+      // Handle session termination
+      if (req.method === 'DELETE') {
+        sessions.delete(mcpSessionId);
+        res.status(200).json({ status: 'terminated' });
+        return;
+      }
+
+      // Forward request to existing transport
+      await entry.transport.handleRequest(req, res, req.body);
+      return;
+    }
+
+    // Create new transport for new sessions
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => crypto.randomUUID(),
+      enableJsonResponse: true,
+      onsessioninitialized: (sessionId) => {
+        sessions.set(sessionId, { transport });
+      },
+    });
+
+    transport.onclose = () => {
+      const sid = transport.sessionId;
+      if (sid) {
+        sessions.delete(sid);
+      }
+    };
+
+    // Create the MCP server
+    const server = await createMcpServer({
+      apiKey: YELP_API_KEY,
+    });
+
+    // Connect server to transport
+    await server.connect(transport);
+
+    // Handle the request
+    await transport.handleRequest(req, res, req.body);
+  } catch (error) {
+    console.error('MCP ERROR:', error);
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32603,
+          message: 'Internal server error',
+        },
+        id: null,
+      });
+    }
+  }
+});
+
+// =============================================================================
+// Health Check
+// =============================================================================
+
+app.get('/health', (_: Request, res: Response) => {
+  res.json({
+    status: 'ok',
+    transport: 'streamable-http',
+    server: 'yelp-fusionai',
+    version: '0.1.0',
+  });
+});
+
+app.get('/info', (_: Request, res: Response) => {
+  res.json({
+    status: 'ok',
+    server: {
+      name: 'yelp-fusionai',
+      version: '0.1.0',
+    },
+    tools: [
+      // Business Search
+      'yelp_search',
+      'yelp_phone_search',
+      'yelp_business_match',
+      'yelp_business_details',
+      // Reviews
+      'yelp_reviews',
+      'yelp_review_highlights',
+      // AI Chat
+      'yelp_ai_chat',
+      'yelp_ai_chat_stream',
+      // Events
+      'yelp_events',
+      'yelp_event_details',
+      'yelp_featured_event',
+      // Autocomplete & Categories
+      'yelp_autocomplete',
+      'yelp_categories',
+      'yelp_category_details',
+      // Transactions
+      'yelp_delivery_search',
+      'yelp_service_offerings',
+      // Insights
+      'yelp_engagement_metrics',
+      'yelp_business_insights',
+      'yelp_food_drinks_insights',
+      'yelp_risk_signals',
+      // Waitlist
+      'yelp_waitlist_status',
+      'yelp_waitlist_info',
+      'yelp_visit_details',
+      'yelp_partner_restaurants',
+      // Reservations
+      'yelp_reservation_openings',
+      'yelp_reservation_status',
+    ],
+  });
+});
+
+// =============================================================================
+// Start Server
+// =============================================================================
+
+app.listen(PORT, () => {
+  console.log(`Yelp Fusion AI MCP Server listening on http://${HOST}:${PORT}`);
+  console.log(`  MCP endpoint: http://${HOST}:${PORT}/mcp`);
+  console.log(`  Health check: http://${HOST}:${PORT}/health`);
+});

--- a/servers/server-yelp-fusionai/src/server-factory.ts
+++ b/servers/server-yelp-fusionai/src/server-factory.ts
@@ -1,0 +1,36 @@
+/**
+ * MCP Server Factory
+ * Creates configured MCP server instances with all Yelp tools registered
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { YelpClient } from './yelp-client/index.js';
+import { registerAllTools } from './tools/index.js';
+
+export interface CreateServerOptions {
+  /** Yelp API key */
+  apiKey: string;
+  /** Optional timeout for API requests (default: 30000ms) */
+  timeout?: number;
+}
+
+/**
+ * Create a new MCP server configured with Yelp Fusion API tools
+ */
+export async function createMcpServer(options: CreateServerOptions): Promise<McpServer> {
+  const { apiKey, timeout } = options;
+
+  // Create the MCP server
+  const server = new McpServer({
+    name: 'yelp-fusionai',
+    version: '0.1.0',
+  });
+
+  // Create the Yelp API client
+  const client = new YelpClient({ apiKey, timeout });
+
+  // Register all tools
+  registerAllTools(server, client);
+
+  return server;
+}

--- a/servers/server-yelp-fusionai/src/tools/ai-chat.ts
+++ b/servers/server-yelp-fusionai/src/tools/ai-chat.ts
@@ -1,0 +1,122 @@
+/**
+ * AI Chat Tool
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { YelpClient } from '../yelp-client/index.js';
+
+// =============================================================================
+// Tool Definitions
+// =============================================================================
+
+export const YELP_AI_CHAT_TOOL = {
+  name: 'yelp_ai_chat',
+  description: `Have a conversation with Yelp's AI assistant about local businesses. The AI can help find businesses, answer questions about them, and provide recommendations.
+
+This is a conversational interface - you can ask follow-up questions by providing the same conversation_id.
+
+Example queries:
+- "What's a good Italian restaurant for a date night in the Marina?"
+- "Tell me more about their menu" (with conversation_id from previous response)
+- "Are there any good coffee shops near Union Square that have outdoor seating?"`,
+  inputSchema: z.object({
+    query: z.string().describe('Your question or request about local businesses'),
+    location: z.string().optional().describe('Location context (e.g., "San Francisco, CA")'),
+    latitude: z.number().optional().describe('Latitude for location context'),
+    longitude: z.number().optional().describe('Longitude for location context'),
+    conversation_id: z.string().optional()
+      .describe('Conversation ID from a previous response for follow-up questions'),
+  }),
+  annotations: { readOnlyHint: true, idempotentHint: false },
+};
+
+export const YELP_AI_CHAT_STREAM_TOOL = {
+  name: 'yelp_ai_chat_stream',
+  description: `Have a streaming conversation with Yelp's AI assistant. Same as yelp_ai_chat but returns responses in chunks as they're generated.
+
+Use this for longer responses or when you want to start processing the response before it's complete.`,
+  inputSchema: z.object({
+    query: z.string().describe('Your question or request about local businesses'),
+    location: z.string().optional().describe('Location context (e.g., "San Francisco, CA")'),
+    latitude: z.number().optional().describe('Latitude for location context'),
+    longitude: z.number().optional().describe('Longitude for location context'),
+    conversation_id: z.string().optional()
+      .describe('Conversation ID from a previous response for follow-up questions'),
+  }),
+  annotations: { readOnlyHint: true, idempotentHint: false },
+};
+
+// =============================================================================
+// Tool Registration
+// =============================================================================
+
+export function registerAIChatTools(server: McpServer, client: YelpClient): void {
+  // Non-streaming AI Chat
+  server.registerTool(
+    YELP_AI_CHAT_TOOL.name,
+    {
+      description: YELP_AI_CHAT_TOOL.description,
+      inputSchema: YELP_AI_CHAT_TOOL.inputSchema,
+      annotations: YELP_AI_CHAT_TOOL.annotations,
+    },
+    async (args) => {
+      const result = await client.chat(args);
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2),
+        }],
+      };
+    }
+  );
+
+  // Streaming AI Chat
+  server.registerTool(
+    YELP_AI_CHAT_STREAM_TOOL.name,
+    {
+      description: YELP_AI_CHAT_STREAM_TOOL.description,
+      inputSchema: YELP_AI_CHAT_STREAM_TOOL.inputSchema,
+      annotations: YELP_AI_CHAT_STREAM_TOOL.annotations,
+    },
+    async (args) => {
+      // Collect streaming response into a single result
+      const chunks: string[] = [];
+      const businesses: unknown[] = [];
+      let conversationId = '';
+
+      for await (const chunk of client.chatStream(args)) {
+        switch (chunk.type) {
+          case 'text':
+            if (chunk.content) {
+              chunks.push(chunk.content);
+            }
+            break;
+          case 'business':
+            if (chunk.business) {
+              businesses.push(chunk.business);
+            }
+            break;
+          case 'end':
+            if (chunk.conversation_id) {
+              conversationId = chunk.conversation_id;
+            }
+            break;
+        }
+      }
+
+      const result = {
+        response: chunks.join(''),
+        conversation_id: conversationId,
+        businesses: businesses.length > 0 ? businesses : undefined,
+      };
+
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2),
+        }],
+      };
+    }
+  );
+}

--- a/servers/server-yelp-fusionai/src/tools/autocomplete.ts
+++ b/servers/server-yelp-fusionai/src/tools/autocomplete.ts
@@ -1,0 +1,52 @@
+/**
+ * Autocomplete Tool
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { YelpClient } from '../yelp-client/index.js';
+
+// =============================================================================
+// Tool Definitions
+// =============================================================================
+
+export const YELP_AUTOCOMPLETE_TOOL = {
+  name: 'yelp_autocomplete',
+  description: `Get autocomplete suggestions for search terms, businesses, and categories. Useful for building search interfaces or suggesting completions.
+
+Returns three types of suggestions:
+- terms: Search term completions
+- businesses: Matching business names
+- categories: Matching category names`,
+  inputSchema: z.object({
+    text: z.string().describe('Text to autocomplete'),
+    latitude: z.number().optional().describe('Latitude for location-based results'),
+    longitude: z.number().optional().describe('Longitude for location-based results'),
+    locale: z.string().optional().describe('Locale code (e.g., "en_US")'),
+  }),
+  annotations: { readOnlyHint: true, idempotentHint: true },
+};
+
+// =============================================================================
+// Tool Registration
+// =============================================================================
+
+export function registerAutocompleteTools(server: McpServer, client: YelpClient): void {
+  server.registerTool(
+    YELP_AUTOCOMPLETE_TOOL.name,
+    {
+      description: YELP_AUTOCOMPLETE_TOOL.description,
+      inputSchema: YELP_AUTOCOMPLETE_TOOL.inputSchema,
+      annotations: YELP_AUTOCOMPLETE_TOOL.annotations,
+    },
+    async (args) => {
+      const result = await client.autocomplete(args);
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2),
+        }],
+      };
+    }
+  );
+}

--- a/servers/server-yelp-fusionai/src/tools/business.ts
+++ b/servers/server-yelp-fusionai/src/tools/business.ts
@@ -1,0 +1,162 @@
+/**
+ * Business Search and Details Tools
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { YelpClient } from '../yelp-client/index.js';
+
+// =============================================================================
+// Tool Definitions
+// =============================================================================
+
+export const YELP_SEARCH_TOOL = {
+  name: 'yelp_search',
+  description: `Search for businesses on Yelp by location and search term. Returns a list of businesses matching the search criteria with ratings, reviews, categories, and location information.
+
+Use this to find restaurants, shops, services, and other businesses in a specific area.
+
+Example queries:
+- "pizza in New York"
+- "coffee shops near me" (requires latitude/longitude)
+- "best rated sushi in San Francisco"`,
+  inputSchema: z.object({
+    term: z.string().optional().describe('Search term (e.g., "food", "restaurants", "coffee")'),
+    location: z.string().optional().describe('Location (e.g., "NYC", "350 5th Ave, New York, NY 10118")'),
+    latitude: z.number().optional().describe('Latitude coordinate'),
+    longitude: z.number().optional().describe('Longitude coordinate'),
+    radius: z.number().max(40000).optional().describe('Search radius in meters (max 40000)'),
+    categories: z.string().optional().describe('Category aliases to filter by (comma-separated)'),
+    price: z.string().optional().describe('Price levels to filter (1-4, comma-separated)'),
+    open_now: z.boolean().optional().describe('Only show businesses open now'),
+    sort_by: z.enum(['best_match', 'rating', 'review_count', 'distance']).optional()
+      .describe('Sort results by: best_match, rating, review_count, or distance'),
+    limit: z.number().max(50).optional().describe('Number of results (max 50)'),
+    offset: z.number().optional().describe('Offset for pagination'),
+  }),
+  annotations: { readOnlyHint: true, idempotentHint: true },
+};
+
+export const YELP_PHONE_SEARCH_TOOL = {
+  name: 'yelp_phone_search',
+  description: `Find a business by its phone number. Useful when you have a phone number and need to look up the business details.
+
+The phone number should be in E.164 format (e.g., +14159083801).`,
+  inputSchema: z.object({
+    phone: z.string().describe('Phone number in E.164 format (e.g., +14159083801)'),
+  }),
+  annotations: { readOnlyHint: true, idempotentHint: true },
+};
+
+export const YELP_BUSINESS_MATCH_TOOL = {
+  name: 'yelp_business_match',
+  description: `Match a business to Yelp's database using its name and address. Useful when you have business details and want to find the corresponding Yelp listing.`,
+  inputSchema: z.object({
+    name: z.string().describe('Business name'),
+    address1: z.string().describe('Street address'),
+    city: z.string().describe('City'),
+    state: z.string().describe('Two-letter state code'),
+    country: z.string().describe('Two-letter country code'),
+    postal_code: z.string().optional().describe('Postal/ZIP code'),
+    phone: z.string().optional().describe('Phone number'),
+    latitude: z.number().optional().describe('Latitude'),
+    longitude: z.number().optional().describe('Longitude'),
+    match_threshold: z.enum(['none', 'default', 'strict']).optional()
+      .describe('Match strictness: none, default, or strict'),
+  }),
+  annotations: { readOnlyHint: true, idempotentHint: true },
+};
+
+export const YELP_BUSINESS_DETAILS_TOOL = {
+  name: 'yelp_business_details',
+  description: `Get detailed information about a specific business by its Yelp business ID.
+
+Returns comprehensive details including hours, photos, reviews, special hours, and more.`,
+  inputSchema: z.object({
+    business_id: z.string().describe('Yelp business ID (e.g., "north-india-restaurant-san-francisco")'),
+    locale: z.string().optional().describe('Locale code (e.g., "en_US")'),
+  }),
+  annotations: { readOnlyHint: true, idempotentHint: true },
+};
+
+// =============================================================================
+// Tool Registration
+// =============================================================================
+
+export function registerBusinessTools(server: McpServer, client: YelpClient): void {
+  // Search businesses
+  server.registerTool(
+    YELP_SEARCH_TOOL.name,
+    {
+      description: YELP_SEARCH_TOOL.description,
+      inputSchema: YELP_SEARCH_TOOL.inputSchema,
+      annotations: YELP_SEARCH_TOOL.annotations,
+    },
+    async (args) => {
+      const result = await client.searchBusinesses(args);
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2),
+        }],
+      };
+    }
+  );
+
+  // Phone search
+  server.registerTool(
+    YELP_PHONE_SEARCH_TOOL.name,
+    {
+      description: YELP_PHONE_SEARCH_TOOL.description,
+      inputSchema: YELP_PHONE_SEARCH_TOOL.inputSchema,
+      annotations: YELP_PHONE_SEARCH_TOOL.annotations,
+    },
+    async (args) => {
+      const result = await client.searchByPhone(args);
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2),
+        }],
+      };
+    }
+  );
+
+  // Business match
+  server.registerTool(
+    YELP_BUSINESS_MATCH_TOOL.name,
+    {
+      description: YELP_BUSINESS_MATCH_TOOL.description,
+      inputSchema: YELP_BUSINESS_MATCH_TOOL.inputSchema,
+      annotations: YELP_BUSINESS_MATCH_TOOL.annotations,
+    },
+    async (args) => {
+      const result = await client.matchBusiness(args);
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2),
+        }],
+      };
+    }
+  );
+
+  // Business details
+  server.registerTool(
+    YELP_BUSINESS_DETAILS_TOOL.name,
+    {
+      description: YELP_BUSINESS_DETAILS_TOOL.description,
+      inputSchema: YELP_BUSINESS_DETAILS_TOOL.inputSchema,
+      annotations: YELP_BUSINESS_DETAILS_TOOL.annotations,
+    },
+    async (args) => {
+      const result = await client.getBusinessDetails(args.business_id, args.locale);
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2),
+        }],
+      };
+    }
+  );
+}

--- a/servers/server-yelp-fusionai/src/tools/categories.ts
+++ b/servers/server-yelp-fusionai/src/tools/categories.ts
@@ -1,0 +1,76 @@
+/**
+ * Categories Tools
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { YelpClient } from '../yelp-client/index.js';
+
+// =============================================================================
+// Tool Definitions
+// =============================================================================
+
+export const YELP_CATEGORIES_TOOL = {
+  name: 'yelp_categories',
+  description: `Get all Yelp business categories. Categories are hierarchical and can be used to filter business searches.
+
+Returns category aliases and titles that can be used with the yelp_search tool's categories parameter.`,
+  inputSchema: z.object({
+    locale: z.string().optional().describe('Locale code (e.g., "en_US") for localized category names'),
+  }),
+  annotations: { readOnlyHint: true, idempotentHint: true },
+};
+
+export const YELP_CATEGORY_DETAILS_TOOL = {
+  name: 'yelp_category_details',
+  description: `Get details about a specific category including its parent categories and country availability.`,
+  inputSchema: z.object({
+    alias: z.string().describe('Category alias (e.g., "pizza", "italian")'),
+    locale: z.string().optional().describe('Locale code (e.g., "en_US")'),
+  }),
+  annotations: { readOnlyHint: true, idempotentHint: true },
+};
+
+// =============================================================================
+// Tool Registration
+// =============================================================================
+
+export function registerCategoriesTools(server: McpServer, client: YelpClient): void {
+  // All categories
+  server.registerTool(
+    YELP_CATEGORIES_TOOL.name,
+    {
+      description: YELP_CATEGORIES_TOOL.description,
+      inputSchema: YELP_CATEGORIES_TOOL.inputSchema,
+      annotations: YELP_CATEGORIES_TOOL.annotations,
+    },
+    async (args) => {
+      const result = await client.getAllCategories(args.locale);
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2),
+        }],
+      };
+    }
+  );
+
+  // Category details
+  server.registerTool(
+    YELP_CATEGORY_DETAILS_TOOL.name,
+    {
+      description: YELP_CATEGORY_DETAILS_TOOL.description,
+      inputSchema: YELP_CATEGORY_DETAILS_TOOL.inputSchema,
+      annotations: YELP_CATEGORY_DETAILS_TOOL.annotations,
+    },
+    async (args) => {
+      const result = await client.getCategoryDetails(args.alias, args.locale);
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2),
+        }],
+      };
+    }
+  );
+}

--- a/servers/server-yelp-fusionai/src/tools/events.ts
+++ b/servers/server-yelp-fusionai/src/tools/events.ts
@@ -1,0 +1,116 @@
+/**
+ * Events Tools
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { YelpClient } from '../yelp-client/index.js';
+
+// =============================================================================
+// Tool Definitions
+// =============================================================================
+
+export const YELP_EVENTS_TOOL = {
+  name: 'yelp_events',
+  description: `Search for events on Yelp. Find concerts, festivals, food & drink events, and more happening in a specific area.`,
+  inputSchema: z.object({
+    location: z.string().optional().describe('Location (e.g., "San Francisco, CA")'),
+    latitude: z.number().optional().describe('Latitude coordinate'),
+    longitude: z.number().optional().describe('Longitude coordinate'),
+    radius: z.number().optional().describe('Search radius in meters'),
+    categories: z.string().optional().describe('Event categories (comma-separated)'),
+    is_free: z.boolean().optional().describe('Only show free events'),
+    start_date: z.number().optional().describe('Events starting after this Unix timestamp'),
+    end_date: z.number().optional().describe('Events starting before this Unix timestamp'),
+    sort_by: z.enum(['desc', 'asc']).optional().describe('Sort direction'),
+    sort_on: z.enum(['popularity', 'time_start']).optional().describe('Sort by popularity or start time'),
+    limit: z.number().max(50).optional().describe('Number of results (max 50)'),
+    offset: z.number().optional().describe('Offset for pagination'),
+  }),
+  annotations: { readOnlyHint: true, idempotentHint: true },
+};
+
+export const YELP_EVENT_DETAILS_TOOL = {
+  name: 'yelp_event_details',
+  description: `Get detailed information about a specific event by its Yelp event ID.`,
+  inputSchema: z.object({
+    event_id: z.string().describe('Yelp event ID'),
+    locale: z.string().optional().describe('Locale code (e.g., "en_US")'),
+  }),
+  annotations: { readOnlyHint: true, idempotentHint: true },
+};
+
+export const YELP_FEATURED_EVENT_TOOL = {
+  name: 'yelp_featured_event',
+  description: `Get the featured event for a location. Yelp highlights notable upcoming events in each area.`,
+  inputSchema: z.object({
+    location: z.string().optional().describe('Location (e.g., "San Francisco, CA")'),
+    latitude: z.number().optional().describe('Latitude coordinate'),
+    longitude: z.number().optional().describe('Longitude coordinate'),
+    locale: z.string().optional().describe('Locale code (e.g., "en_US")'),
+  }),
+  annotations: { readOnlyHint: true, idempotentHint: true },
+};
+
+// =============================================================================
+// Tool Registration
+// =============================================================================
+
+export function registerEventsTools(server: McpServer, client: YelpClient): void {
+  // Search events
+  server.registerTool(
+    YELP_EVENTS_TOOL.name,
+    {
+      description: YELP_EVENTS_TOOL.description,
+      inputSchema: YELP_EVENTS_TOOL.inputSchema,
+      annotations: YELP_EVENTS_TOOL.annotations,
+    },
+    async (args) => {
+      const result = await client.searchEvents(args);
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2),
+        }],
+      };
+    }
+  );
+
+  // Event details
+  server.registerTool(
+    YELP_EVENT_DETAILS_TOOL.name,
+    {
+      description: YELP_EVENT_DETAILS_TOOL.description,
+      inputSchema: YELP_EVENT_DETAILS_TOOL.inputSchema,
+      annotations: YELP_EVENT_DETAILS_TOOL.annotations,
+    },
+    async (args) => {
+      const result = await client.getEventDetails(args.event_id, args.locale);
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2),
+        }],
+      };
+    }
+  );
+
+  // Featured event
+  server.registerTool(
+    YELP_FEATURED_EVENT_TOOL.name,
+    {
+      description: YELP_FEATURED_EVENT_TOOL.description,
+      inputSchema: YELP_FEATURED_EVENT_TOOL.inputSchema,
+      annotations: YELP_FEATURED_EVENT_TOOL.annotations,
+    },
+    async (args) => {
+      const result = await client.getFeaturedEvent(args);
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2),
+        }],
+      };
+    }
+  );
+}

--- a/servers/server-yelp-fusionai/src/tools/index.ts
+++ b/servers/server-yelp-fusionai/src/tools/index.ts
@@ -1,0 +1,52 @@
+/**
+ * Tool Registry - Registers all Yelp tools with the MCP server
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { YelpClient } from '../yelp-client/index.js';
+
+import { registerBusinessTools } from './business.js';
+import { registerReviewsTools } from './reviews.js';
+import { registerAIChatTools } from './ai-chat.js';
+import { registerEventsTools } from './events.js';
+import { registerAutocompleteTools } from './autocomplete.js';
+import { registerCategoriesTools } from './categories.js';
+import { registerTransactionTools } from './transactions.js';
+import { registerInsightsTools } from './insights.js';
+import { registerWaitlistTools } from './waitlist.js';
+import { registerReservationTools } from './reservations.js';
+
+/**
+ * Register all Yelp Fusion API tools with the MCP server
+ */
+export function registerAllTools(server: McpServer, client: YelpClient): void {
+  // P0: Core Business APIs
+  registerBusinessTools(server, client);
+  registerReviewsTools(server, client);
+  registerAIChatTools(server, client);
+
+  // P1: Additional APIs
+  registerEventsTools(server, client);
+  registerAutocompleteTools(server, client);
+
+  // P2: Categories
+  registerCategoriesTools(server, client);
+
+  // v3 Extended APIs
+  registerTransactionTools(server, client);
+  registerInsightsTools(server, client);
+  registerWaitlistTools(server, client);
+  registerReservationTools(server, client);
+}
+
+// Re-export individual registrations for selective use
+export { registerBusinessTools } from './business.js';
+export { registerReviewsTools } from './reviews.js';
+export { registerAIChatTools } from './ai-chat.js';
+export { registerEventsTools } from './events.js';
+export { registerAutocompleteTools } from './autocomplete.js';
+export { registerCategoriesTools } from './categories.js';
+export { registerTransactionTools } from './transactions.js';
+export { registerInsightsTools } from './insights.js';
+export { registerWaitlistTools } from './waitlist.js';
+export { registerReservationTools } from './reservations.js';

--- a/servers/server-yelp-fusionai/src/tools/insights.ts
+++ b/servers/server-yelp-fusionai/src/tools/insights.ts
@@ -1,0 +1,137 @@
+/**
+ * Business Insights Tools
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { YelpClient } from '../yelp-client/index.js';
+
+export function registerInsightsTools(server: McpServer, client: YelpClient): void {
+  // Engagement Metrics Tool
+  server.tool(
+    'yelp_engagement_metrics',
+    'Get engagement metrics (impressions, leads, calls, etc.) for businesses',
+    {
+      business_ids: z.string().describe('Comma-separated list of business IDs (max 50)'),
+      start_date: z.string().optional().describe('Start date (YYYY-MM-DD)'),
+      end_date: z.string().optional().describe('End date (YYYY-MM-DD)'),
+    },
+    async (args) => {
+      try {
+        const result = await client.getEngagementMetrics({
+          business_ids: args.business_ids,
+          start_date: args.start_date,
+          end_date: args.end_date,
+        });
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // Business Insights Tool
+  server.tool(
+    'yelp_business_insights',
+    'Get insights data for businesses',
+    {
+      business_ids: z.string().describe('Comma-separated list of business IDs'),
+      locale: z.string().optional().describe('Locale code (e.g., "en_US")'),
+    },
+    async (args) => {
+      try {
+        const result = await client.getBusinessInsights({
+          business_ids: args.business_ids,
+          locale: args.locale,
+        });
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // Food & Drinks Insights Tool
+  server.tool(
+    'yelp_food_drinks_insights',
+    'Get popular dishes and drinks insights for a business',
+    {
+      business_id: z.string().describe('The Yelp business ID'),
+      locale: z.string().optional().describe('Locale code (e.g., "en_US")'),
+    },
+    async (args) => {
+      try {
+        const result = await client.getFoodDrinksInsights(args.business_id, args.locale);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // Risk Signals Insights Tool
+  server.tool(
+    'yelp_risk_signals',
+    'Get risk signal insights for a business (potential issues or concerns)',
+    {
+      business_id: z.string().describe('The Yelp business ID'),
+      locale: z.string().optional().describe('Locale code (e.g., "en_US")'),
+    },
+    async (args) => {
+      try {
+        const result = await client.getRiskSignalsInsights(args.business_id, args.locale);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/servers/server-yelp-fusionai/src/tools/reservations.ts
+++ b/servers/server-yelp-fusionai/src/tools/reservations.ts
@@ -1,0 +1,77 @@
+/**
+ * Reservations Tools
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { YelpClient } from '../yelp-client/index.js';
+
+export function registerReservationTools(server: McpServer, client: YelpClient): void {
+  // Reservation Openings Tool
+  server.tool(
+    'yelp_reservation_openings',
+    'Get available reservation times for a restaurant',
+    {
+      business_id_or_alias: z.string().describe('Business ID or alias'),
+      covers: z.number().min(1).max(10).describe('Number of people (1-10)'),
+      date: z.string().describe('Date in YYYY-MM-DD format'),
+      time: z.string().describe('Time in HH:MM format'),
+      get_covers_range: z.boolean().optional().describe('Include party size range info'),
+    },
+    async (args) => {
+      try {
+        const result = await client.getReservationOpenings({
+          business_id_or_alias: args.business_id_or_alias,
+          covers: args.covers,
+          date: args.date,
+          time: args.time,
+          get_covers_range: args.get_covers_range,
+        });
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // Reservation Status Tool
+  server.tool(
+    'yelp_reservation_status',
+    'Get the status of a reservation',
+    {
+      reservation_id: z.string().describe('The reservation ID'),
+    },
+    async (args) => {
+      try {
+        const result = await client.getReservationStatus(args.reservation_id);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/servers/server-yelp-fusionai/src/tools/reviews.ts
+++ b/servers/server-yelp-fusionai/src/tools/reviews.ts
@@ -1,0 +1,82 @@
+/**
+ * Reviews Tools
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { YelpClient } from '../yelp-client/index.js';
+
+// =============================================================================
+// Tool Definitions
+// =============================================================================
+
+export const YELP_REVIEWS_TOOL = {
+  name: 'yelp_reviews',
+  description: `Get reviews for a specific business. Returns up to 50 reviews with text, rating, and user information.
+
+Reviews are a great way to understand customer experiences and sentiment about a business.`,
+  inputSchema: z.object({
+    business_id: z.string().describe('Yelp business ID'),
+    locale: z.string().optional().describe('Locale code (e.g., "en_US")'),
+    sort_by: z.enum(['yelp_sort', 'newest', 'oldest', 'elites']).optional()
+      .describe('Sort order: yelp_sort (default), newest, oldest, or elites'),
+    limit: z.number().max(50).optional().describe('Number of reviews (max 50)'),
+    offset: z.number().optional().describe('Offset for pagination'),
+  }),
+  annotations: { readOnlyHint: true, idempotentHint: true },
+};
+
+export const YELP_REVIEW_HIGHLIGHTS_TOOL = {
+  name: 'yelp_review_highlights',
+  description: `Get highlighted snippets from reviews for a business. These are the most notable and representative excerpts that capture key customer experiences.
+
+Useful for quickly understanding what customers commonly mention about a business.`,
+  inputSchema: z.object({
+    business_id: z.string().describe('Yelp business ID'),
+  }),
+  annotations: { readOnlyHint: true, idempotentHint: true },
+};
+
+// =============================================================================
+// Tool Registration
+// =============================================================================
+
+export function registerReviewsTools(server: McpServer, client: YelpClient): void {
+  // Reviews
+  server.registerTool(
+    YELP_REVIEWS_TOOL.name,
+    {
+      description: YELP_REVIEWS_TOOL.description,
+      inputSchema: YELP_REVIEWS_TOOL.inputSchema,
+      annotations: YELP_REVIEWS_TOOL.annotations,
+    },
+    async (args) => {
+      const result = await client.getReviews(args);
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2),
+        }],
+      };
+    }
+  );
+
+  // Review highlights
+  server.registerTool(
+    YELP_REVIEW_HIGHLIGHTS_TOOL.name,
+    {
+      description: YELP_REVIEW_HIGHLIGHTS_TOOL.description,
+      inputSchema: YELP_REVIEW_HIGHLIGHTS_TOOL.inputSchema,
+      annotations: YELP_REVIEW_HIGHLIGHTS_TOOL.annotations,
+    },
+    async (args) => {
+      const result = await client.getReviewHighlights(args.business_id);
+      return {
+        content: [{
+          type: 'text' as const,
+          text: JSON.stringify(result, null, 2),
+        }],
+      };
+    }
+  );
+}

--- a/servers/server-yelp-fusionai/src/tools/transactions.ts
+++ b/servers/server-yelp-fusionai/src/tools/transactions.ts
@@ -1,0 +1,81 @@
+/**
+ * Transaction Search Tools
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { YelpClient } from '../yelp-client/index.js';
+
+export function registerTransactionTools(server: McpServer, client: YelpClient): void {
+  // Food Delivery Search Tool
+  server.tool(
+    'yelp_delivery_search',
+    'Search for businesses that support food delivery in a location',
+    {
+      location: z.string().optional().describe('Location (e.g., "NYC", "San Francisco, CA")'),
+      latitude: z.number().optional().describe('Latitude of the location'),
+      longitude: z.number().optional().describe('Longitude of the location'),
+      term: z.string().optional().describe('Search term (e.g., "pizza", "sushi")'),
+      categories: z.array(z.string()).optional().describe('Category filters'),
+      price: z.array(z.number().min(1).max(4)).optional().describe('Price levels (1-4)'),
+    },
+    async (args) => {
+      try {
+        const result = await client.searchTransactions({
+          transaction_type: 'delivery',
+          location: args.location,
+          latitude: args.latitude,
+          longitude: args.longitude,
+          term: args.term,
+          categories: args.categories,
+          price: args.price,
+        });
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // Service Offerings Tool
+  server.tool(
+    'yelp_service_offerings',
+    'Get available service offerings for a business (delivery, pickup, etc.)',
+    {
+      business_id: z.string().describe('The Yelp business ID'),
+      locale: z.string().optional().describe('Locale code (e.g., "en_US")'),
+    },
+    async (args) => {
+      try {
+        const result = await client.getServiceOfferings(args.business_id, args.locale);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/servers/server-yelp-fusionai/src/tools/waitlist.ts
+++ b/servers/server-yelp-fusionai/src/tools/waitlist.ts
@@ -1,0 +1,137 @@
+/**
+ * Waitlist Tools
+ */
+
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { YelpClient } from '../yelp-client/index.js';
+
+export function registerWaitlistTools(server: McpServer, client: YelpClient): void {
+  // Waitlist Status Tool
+  server.tool(
+    'yelp_waitlist_status',
+    'Get the current waitlist status and wait estimates for a business',
+    {
+      business_id: z.string().describe('The Yelp business ID'),
+    },
+    async (args) => {
+      try {
+        const result = await client.getWaitlistStatus(args.business_id);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // Waitlist Info Tool
+  server.tool(
+    'yelp_waitlist_info',
+    'Get waitlist configuration and operating hours for a business',
+    {
+      business_id: z.string().describe('The Yelp business ID'),
+    },
+    async (args) => {
+      try {
+        const result = await client.getWaitlistInfo(args.business_id);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // Visit Details Tool
+  server.tool(
+    'yelp_visit_details',
+    'Get details of a specific waitlist visit',
+    {
+      visit_id: z.string().describe('The visit ID'),
+    },
+    async (args) => {
+      try {
+        const result = await client.getVisitDetails(args.visit_id);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // Partner Restaurants Tool
+  server.tool(
+    'yelp_partner_restaurants',
+    'Find restaurants that support Yelp Waitlist in a location',
+    {
+      location: z.string().optional().describe('Location string'),
+      latitude: z.number().optional().describe('Latitude'),
+      longitude: z.number().optional().describe('Longitude'),
+      radius: z.number().optional().describe('Search radius in meters'),
+      limit: z.number().optional().describe('Number of results to return'),
+      offset: z.number().optional().describe('Offset for pagination'),
+    },
+    async (args) => {
+      try {
+        const result = await client.getPartnerRestaurants({
+          location: args.location,
+          latitude: args.latitude,
+          longitude: args.longitude,
+          radius: args.radius,
+          limit: args.limit,
+          offset: args.offset,
+        });
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+}

--- a/servers/server-yelp-fusionai/src/yelp-client/index.ts
+++ b/servers/server-yelp-fusionai/src/yelp-client/index.ts
@@ -1,0 +1,487 @@
+/**
+ * Yelp Fusion API Client
+ */
+
+import type {
+  Business,
+  BusinessSearchParams,
+  BusinessSearchResult,
+  PhoneSearchParams,
+  BusinessMatchParams,
+  BusinessMatchResult,
+  ReviewsParams,
+  ReviewsResult,
+  ReviewHighlightsResult,
+  EventSearchParams,
+  EventSearchResult,
+  Event,
+  AutocompleteParams,
+  AutocompleteResult,
+  CategoriesResult,
+  CategoryDetails,
+  AIChatParams,
+  AIChatResponse,
+  AIChatStreamChunk,
+  YelpApiError,
+  TransactionSearchParams,
+  TransactionSearchResult,
+  ServiceOfferingsResult,
+  EngagementMetricsParams,
+  EngagementMetricsResult,
+  BusinessInsightsParams,
+  BusinessInsightsResult,
+  FoodDrinksInsightsResult,
+  RiskSignalsInsightsResult,
+  WaitlistStatusResult,
+  WaitlistInfoResult,
+  VisitResult,
+  PartnerRestaurantsParams,
+  PartnerRestaurantsResult,
+  ReservationOpeningsParams,
+  ReservationOpeningsResult,
+  ReservationStatusResult,
+} from './types.js';
+import { YelpError } from './types.js';
+
+const YELP_API_BASE = 'https://api.yelp.com/v3';
+const YELP_AI_API_BASE = 'https://api.yelp.com/v2';
+
+/**
+ * Convert a typed params object to Record<string, unknown> for URL encoding
+ */
+function toRecord<T extends object>(params: T): Record<string, unknown> {
+  return params as unknown as Record<string, unknown>;
+}
+
+export interface YelpClientOptions {
+  apiKey: string;
+  timeout?: number;
+}
+
+export class YelpClient {
+  private apiKey: string;
+  private timeout: number;
+
+  constructor(options: YelpClientOptions) {
+    this.apiKey = options.apiKey;
+    this.timeout = options.timeout ?? 30000;
+  }
+
+  private async request<T>(
+    endpoint: string,
+    params?: Record<string, unknown>,
+    options?: { base?: string; method?: string; body?: unknown }
+  ): Promise<T> {
+    const base = options?.base ?? YELP_API_BASE;
+    const method = options?.method ?? 'GET';
+
+    let url = `${base}${endpoint}`;
+
+    if (method === 'GET' && params) {
+      const searchParams = new URLSearchParams();
+      for (const [key, value] of Object.entries(params)) {
+        if (value !== undefined && value !== null) {
+          searchParams.append(key, String(value));
+        }
+      }
+      const queryString = searchParams.toString();
+      if (queryString) {
+        url += `?${queryString}`;
+      }
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers: {
+          'Authorization': `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+        body: method !== 'GET' && options?.body ? JSON.stringify(options.body) : undefined,
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        const errorData = await response.json() as YelpApiError;
+        throw new YelpError(errorData.error);
+      }
+
+      return await response.json() as T;
+    } catch (error) {
+      clearTimeout(timeoutId);
+      if (error instanceof YelpError) {
+        throw error;
+      }
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new Error('Request timed out');
+      }
+      throw error;
+    }
+  }
+
+  // ==========================================================================
+  // Business Search Endpoints
+  // ==========================================================================
+
+  /**
+   * Search for businesses based on location and search term
+   */
+  async searchBusinesses(params: BusinessSearchParams): Promise<BusinessSearchResult> {
+    return this.request<BusinessSearchResult>('/businesses/search', toRecord(params));
+  }
+
+  /**
+   * Search for a business by phone number
+   */
+  async searchByPhone(params: PhoneSearchParams): Promise<BusinessSearchResult> {
+    return this.request<BusinessSearchResult>('/businesses/search/phone', toRecord(params));
+  }
+
+  /**
+   * Match a business to Yelp's database based on provided details
+   */
+  async matchBusiness(params: BusinessMatchParams): Promise<BusinessMatchResult> {
+    return this.request<BusinessMatchResult>('/businesses/matches', toRecord(params));
+  }
+
+  /**
+   * Get detailed information about a specific business
+   */
+  async getBusinessDetails(businessId: string, locale?: string): Promise<Business> {
+    const params = locale ? { locale } : undefined;
+    return this.request<Business>(`/businesses/${encodeURIComponent(businessId)}`, params);
+  }
+
+  // ==========================================================================
+  // Reviews Endpoints
+  // ==========================================================================
+
+  /**
+   * Get reviews for a specific business
+   */
+  async getReviews(params: ReviewsParams): Promise<ReviewsResult> {
+    const { business_id, ...queryParams } = params;
+    return this.request<ReviewsResult>(
+      `/businesses/${encodeURIComponent(business_id)}/reviews`,
+      toRecord(queryParams)
+    );
+  }
+
+  /**
+   * Get review highlights for a specific business
+   */
+  async getReviewHighlights(businessId: string): Promise<ReviewHighlightsResult> {
+    return this.request<ReviewHighlightsResult>(
+      `/businesses/${encodeURIComponent(businessId)}/review_highlights`
+    );
+  }
+
+  // ==========================================================================
+  // Events Endpoints
+  // ==========================================================================
+
+  /**
+   * Search for events
+   */
+  async searchEvents(params?: EventSearchParams): Promise<EventSearchResult> {
+    return this.request<EventSearchResult>('/events', params ? toRecord(params) : undefined);
+  }
+
+  /**
+   * Get details for a specific event
+   */
+  async getEventDetails(eventId: string, locale?: string): Promise<Event> {
+    const params = locale ? { locale } : undefined;
+    return this.request<Event>(`/events/${encodeURIComponent(eventId)}`, params);
+  }
+
+  /**
+   * Get the featured event for a location
+   */
+  async getFeaturedEvent(params: { location?: string; latitude?: number; longitude?: number; locale?: string }): Promise<Event> {
+    return this.request<Event>('/events/featured', toRecord(params));
+  }
+
+  // ==========================================================================
+  // Autocomplete Endpoint
+  // ==========================================================================
+
+  /**
+   * Get autocomplete suggestions
+   */
+  async autocomplete(params: AutocompleteParams): Promise<AutocompleteResult> {
+    return this.request<AutocompleteResult>('/autocomplete', toRecord(params));
+  }
+
+  // ==========================================================================
+  // Categories Endpoints
+  // ==========================================================================
+
+  /**
+   * Get all categories
+   */
+  async getAllCategories(locale?: string): Promise<CategoriesResult> {
+    const params = locale ? { locale } : undefined;
+    return this.request<CategoriesResult>('/categories', params);
+  }
+
+  /**
+   * Get details for a specific category
+   */
+  async getCategoryDetails(alias: string, locale?: string): Promise<{ category: CategoryDetails }> {
+    const params = locale ? { locale } : undefined;
+    return this.request<{ category: CategoryDetails }>(`/categories/${encodeURIComponent(alias)}`, params);
+  }
+
+  // ==========================================================================
+  // Transaction Search Endpoint
+  // ==========================================================================
+
+  /**
+   * Search for businesses that support food delivery
+   */
+  async searchTransactions(params: TransactionSearchParams): Promise<TransactionSearchResult> {
+    const { transaction_type, ...queryParams } = params;
+    return this.request<TransactionSearchResult>(
+      `/transactions/${encodeURIComponent(transaction_type)}/search`,
+      toRecord(queryParams)
+    );
+  }
+
+  // ==========================================================================
+  // Service Offerings Endpoint
+  // ==========================================================================
+
+  /**
+   * Get service offerings for a business
+   */
+  async getServiceOfferings(businessId: string, locale?: string): Promise<ServiceOfferingsResult> {
+    const params = locale ? { locale } : undefined;
+    return this.request<ServiceOfferingsResult>(
+      `/businesses/${encodeURIComponent(businessId)}/service_offerings`,
+      params
+    );
+  }
+
+  // ==========================================================================
+  // Engagement Metrics Endpoint
+  // ==========================================================================
+
+  /**
+   * Get engagement metrics for businesses
+   */
+  async getEngagementMetrics(params: EngagementMetricsParams): Promise<EngagementMetricsResult> {
+    return this.request<EngagementMetricsResult>('/businesses/engagement', toRecord(params));
+  }
+
+  // ==========================================================================
+  // Business Insights Endpoints
+  // ==========================================================================
+
+  /**
+   * Get business insights
+   */
+  async getBusinessInsights(params: BusinessInsightsParams): Promise<BusinessInsightsResult> {
+    return this.request<BusinessInsightsResult>('/businesses/insights', toRecord(params));
+  }
+
+  /**
+   * Get food and drinks insights for a business
+   */
+  async getFoodDrinksInsights(businessId: string, locale?: string): Promise<FoodDrinksInsightsResult> {
+    const params = locale ? { locale } : undefined;
+    return this.request<FoodDrinksInsightsResult>(
+      `/businesses/${encodeURIComponent(businessId)}/food_and_drinks_insights`,
+      params
+    );
+  }
+
+  /**
+   * Get risk signal insights for a business
+   */
+  async getRiskSignalsInsights(businessId: string, locale?: string): Promise<RiskSignalsInsightsResult> {
+    const params = locale ? { locale } : undefined;
+    return this.request<RiskSignalsInsightsResult>(
+      `/businesses/${encodeURIComponent(businessId)}/risk_signals_insights`,
+      params
+    );
+  }
+
+  // ==========================================================================
+  // Waitlist Endpoints
+  // ==========================================================================
+
+  /**
+   * Get waitlist status for a business
+   */
+  async getWaitlistStatus(businessId: string): Promise<WaitlistStatusResult> {
+    return this.request<WaitlistStatusResult>(
+      `/businesses/${encodeURIComponent(businessId)}/waitlist/status`
+    );
+  }
+
+  /**
+   * Get waitlist info for a business
+   */
+  async getWaitlistInfo(businessId: string): Promise<WaitlistInfoResult> {
+    return this.request<WaitlistInfoResult>(
+      `/businesses/${encodeURIComponent(businessId)}/waitlist/info`
+    );
+  }
+
+  /**
+   * Get details of a waitlist visit
+   */
+  async getVisitDetails(visitId: string): Promise<VisitResult> {
+    return this.request<VisitResult>(`/waitlist/visits/${encodeURIComponent(visitId)}`);
+  }
+
+  /**
+   * Get partner restaurants with waitlist support
+   */
+  async getPartnerRestaurants(params?: PartnerRestaurantsParams): Promise<PartnerRestaurantsResult> {
+    return this.request<PartnerRestaurantsResult>(
+      '/waitlist/partner_restaurants',
+      params ? toRecord(params) : undefined
+    );
+  }
+
+  // ==========================================================================
+  // Reservations Endpoints
+  // ==========================================================================
+
+  /**
+   * Get reservation openings for a business
+   */
+  async getReservationOpenings(params: ReservationOpeningsParams): Promise<ReservationOpeningsResult> {
+    const { business_id_or_alias, ...queryParams } = params;
+    return this.request<ReservationOpeningsResult>(
+      `/bookings/${encodeURIComponent(business_id_or_alias)}/openings`,
+      toRecord(queryParams)
+    );
+  }
+
+  /**
+   * Get reservation status
+   */
+  async getReservationStatus(reservationId: string): Promise<ReservationStatusResult> {
+    return this.request<ReservationStatusResult>(
+      `/reservations/${encodeURIComponent(reservationId)}/status`
+    );
+  }
+
+  // ==========================================================================
+  // AI Chat Endpoint
+  // ==========================================================================
+
+  /**
+   * Send a message to the Yelp AI Chat (non-streaming)
+   */
+  async chat(params: AIChatParams): Promise<AIChatResponse> {
+    return this.request<AIChatResponse>(
+      '/ai/chat',
+      undefined,
+      {
+        base: YELP_AI_API_BASE,
+        method: 'POST',
+        body: params,
+      }
+    );
+  }
+
+  /**
+   * Send a message to the Yelp AI Chat with streaming response
+   * Returns an async generator that yields chunks
+   */
+  async *chatStream(params: AIChatParams): AsyncGenerator<AIChatStreamChunk, void, unknown> {
+    const url = `${YELP_AI_API_BASE}/ai/chat`;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout * 2); // Double timeout for streaming
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+          'Accept': 'text/event-stream',
+        },
+        body: JSON.stringify({ ...params, stream: true }),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        const errorData = await response.json() as YelpApiError;
+        throw new YelpError(errorData.error);
+      }
+
+      if (!response.body) {
+        throw new Error('Response body is null');
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+
+        if (done) {
+          break;
+        }
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (line.startsWith('data: ')) {
+            const data = line.slice(6).trim();
+            if (data === '[DONE]') {
+              return;
+            }
+            try {
+              const chunk = JSON.parse(data) as AIChatStreamChunk;
+              yield chunk;
+            } catch {
+              // Skip malformed JSON
+            }
+          }
+        }
+      }
+
+      // Process any remaining data in the buffer
+      if (buffer.startsWith('data: ')) {
+        const data = buffer.slice(6).trim();
+        if (data && data !== '[DONE]') {
+          try {
+            const chunk = JSON.parse(data) as AIChatStreamChunk;
+            yield chunk;
+          } catch {
+            // Skip malformed JSON
+          }
+        }
+      }
+    } catch (error) {
+      clearTimeout(timeoutId);
+      if (error instanceof YelpError) {
+        throw error;
+      }
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new Error('Request timed out');
+      }
+      throw error;
+    }
+  }
+}
+
+export * from './types.js';

--- a/servers/server-yelp-fusionai/src/yelp-client/types.ts
+++ b/servers/server-yelp-fusionai/src/yelp-client/types.ts
@@ -1,0 +1,621 @@
+/**
+ * Yelp Fusion API TypeScript types
+ */
+
+// =============================================================================
+// Common Types
+// =============================================================================
+
+export interface Category {
+  alias: string;
+  title: string;
+}
+
+export interface Coordinates {
+  latitude: number;
+  longitude: number;
+}
+
+export interface Location {
+  address1: string | null;
+  address2: string | null;
+  address3: string | null;
+  city: string;
+  zip_code: string;
+  country: string;
+  state: string;
+  display_address: string[];
+  cross_streets?: string;
+}
+
+export interface BusinessHours {
+  open: Array<{
+    is_overnight: boolean;
+    start: string;
+    end: string;
+    day: number;
+  }>;
+  hours_type: string;
+  is_open_now: boolean;
+}
+
+export interface SpecialHours {
+  date: string;
+  is_closed: boolean | null;
+  start: string | null;
+  end: string | null;
+  is_overnight: boolean | null;
+}
+
+// =============================================================================
+// Business Types
+// =============================================================================
+
+export interface Business {
+  id: string;
+  alias: string;
+  name: string;
+  image_url: string;
+  is_claimed?: boolean;
+  is_closed: boolean;
+  url: string;
+  phone: string;
+  display_phone: string;
+  review_count: number;
+  categories: Category[];
+  rating: number;
+  location: Location;
+  coordinates: Coordinates;
+  photos?: string[];
+  price?: string;
+  hours?: BusinessHours[];
+  special_hours?: SpecialHours[];
+  transactions: string[];
+  messaging?: {
+    url: string;
+    use_case_text: string;
+  };
+  attributes?: Record<string, unknown>;
+}
+
+export interface BusinessSearchResult {
+  businesses: Business[];
+  total: number;
+  region: {
+    center: Coordinates;
+  };
+}
+
+// =============================================================================
+// Search Parameters
+// =============================================================================
+
+export interface BusinessSearchParams {
+  /** Search term (e.g., "food", "restaurants") */
+  term?: string;
+  /** Location (e.g., "NYC", "350 5th Ave, New York, NY 10118") */
+  location?: string;
+  /** Latitude of the location */
+  latitude?: number;
+  /** Longitude of the location */
+  longitude?: number;
+  /** Search radius in meters. Max 40000 meters (25 miles) */
+  radius?: number;
+  /** Categories to filter by (comma-separated aliases) */
+  categories?: string;
+  /** Locale code (e.g., "en_US") */
+  locale?: string;
+  /** Price levels to filter by (1=cheap, 4=expensive). Comma-separated. */
+  price?: string;
+  /** Filter to businesses that are open now */
+  open_now?: boolean;
+  /** Unix timestamp to filter businesses open at that time */
+  open_at?: number;
+  /** Business attributes to filter by */
+  attributes?: string;
+  /** Sort by: best_match, rating, review_count, distance */
+  sort_by?: 'best_match' | 'rating' | 'review_count' | 'distance';
+  /** Device platform: android, ios, mobile-generic */
+  device_platform?: string;
+  /** Reservation date (YYYY-MM-DD) */
+  reservation_date?: string;
+  /** Reservation time (HH:MM) */
+  reservation_time?: string;
+  /** Number of people for reservation */
+  reservation_covers?: number;
+  /** Match threshold for fuzzy matching */
+  matches_party_size_param?: boolean;
+  /** Number of results to return (max 50) */
+  limit?: number;
+  /** Offset for pagination */
+  offset?: number;
+}
+
+export interface PhoneSearchParams {
+  /** Phone number to search for (format: +14159083801) */
+  phone: string;
+}
+
+export interface BusinessMatchParams {
+  /** Business name */
+  name: string;
+  /** Street address */
+  address1: string;
+  /** City */
+  city: string;
+  /** Two-letter state code */
+  state: string;
+  /** Two-letter country code */
+  country: string;
+  /** Postal code */
+  postal_code?: string;
+  /** Address line 2 */
+  address2?: string;
+  /** Address line 3 */
+  address3?: string;
+  /** Phone number */
+  phone?: string;
+  /** Latitude */
+  latitude?: number;
+  /** Longitude */
+  longitude?: number;
+  /** Match threshold: none, default, strict */
+  match_threshold?: 'none' | 'default' | 'strict';
+}
+
+export interface BusinessMatchResult {
+  businesses: Business[];
+}
+
+// =============================================================================
+// Reviews Types
+// =============================================================================
+
+export interface User {
+  id: string;
+  profile_url: string;
+  image_url: string | null;
+  name: string;
+}
+
+export interface Review {
+  id: string;
+  url: string;
+  text: string;
+  rating: number;
+  time_created: string;
+  user: User;
+}
+
+export interface ReviewsResult {
+  reviews: Review[];
+  total: number;
+  possible_languages: string[];
+}
+
+export interface ReviewsParams {
+  /** Business ID */
+  business_id: string;
+  /** Locale code */
+  locale?: string;
+  /** Sort by: yelp_sort, newest, oldest, elites */
+  sort_by?: 'yelp_sort' | 'newest' | 'oldest' | 'elites';
+  /** Number of reviews to return (max 50) */
+  limit?: number;
+  /** Offset for pagination */
+  offset?: number;
+}
+
+export interface ReviewHighlight {
+  sentence: {
+    text: string;
+    offset: number;
+    length: number;
+  };
+  highlight_type: string;
+}
+
+export interface ReviewHighlightsResult {
+  review_highlights: Array<{
+    sentences: string[];
+    review_id: string;
+    user_id: string;
+  }>;
+  request_id: string;
+}
+
+// =============================================================================
+// Events Types
+// =============================================================================
+
+export interface Event {
+  attending_count: number;
+  category: string;
+  cost: number | null;
+  cost_max: number | null;
+  description: string;
+  event_site_url: string;
+  id: string;
+  image_url: string;
+  interested_count: number;
+  is_canceled: boolean;
+  is_free: boolean;
+  is_official: boolean;
+  latitude: number;
+  longitude: number;
+  name: string;
+  tickets_url: string | null;
+  time_end: string | null;
+  time_start: string;
+  location: Location;
+  business_id: string | null;
+}
+
+export interface EventSearchResult {
+  events: Event[];
+  total: number;
+}
+
+export interface EventSearchParams {
+  /** Locale code */
+  locale?: string;
+  /** Offset for pagination */
+  offset?: number;
+  /** Number of results (max 50) */
+  limit?: number;
+  /** Sort by: desc, asc */
+  sort_by?: 'desc' | 'asc';
+  /** Sort on: popularity, time_start */
+  sort_on?: 'popularity' | 'time_start';
+  /** Filter to events starting after this date (Unix timestamp) */
+  start_date?: number;
+  /** Filter to events starting before this date (Unix timestamp) */
+  end_date?: number;
+  /** Event categories (comma-separated) */
+  categories?: string;
+  /** Filter to free events */
+  is_free?: boolean;
+  /** Location string */
+  location?: string;
+  /** Latitude */
+  latitude?: number;
+  /** Longitude */
+  longitude?: number;
+  /** Search radius in meters */
+  radius?: number;
+  /** Comma-separated list of event IDs to exclude */
+  excluded_events?: string;
+}
+
+// =============================================================================
+// Autocomplete Types
+// =============================================================================
+
+export interface AutocompleteResult {
+  terms: Array<{ text: string }>;
+  businesses: Array<{ id: string; name: string }>;
+  categories: Array<{ alias: string; title: string }>;
+}
+
+export interface AutocompleteParams {
+  /** Text to autocomplete */
+  text: string;
+  /** Latitude for location-based results */
+  latitude?: number;
+  /** Longitude for location-based results */
+  longitude?: number;
+  /** Locale code */
+  locale?: string;
+}
+
+// =============================================================================
+// Categories Types
+// =============================================================================
+
+export interface CategoryDetails {
+  alias: string;
+  title: string;
+  parent_aliases: string[];
+  country_whitelist: string[];
+  country_blacklist: string[];
+}
+
+export interface CategoriesResult {
+  categories: CategoryDetails[];
+}
+
+// =============================================================================
+// AI Chat Types
+// =============================================================================
+
+export interface AIChatParams {
+  /** The user's message/query */
+  query: string;
+  /** Location context for the query */
+  location?: string;
+  /** Latitude for location context */
+  latitude?: number;
+  /** Longitude for location context */
+  longitude?: number;
+  /** Conversation ID for multi-turn conversations */
+  conversation_id?: string;
+}
+
+export interface AIChatResponse {
+  /** The AI's response text */
+  response: string;
+  /** Conversation ID for continuing the conversation */
+  conversation_id: string;
+  /** Businesses mentioned in the response */
+  businesses?: Business[];
+}
+
+export interface AIChatStreamChunk {
+  /** Type of chunk: text, business, end */
+  type: 'text' | 'business' | 'end';
+  /** Text content (for text chunks) */
+  content?: string;
+  /** Business data (for business chunks) */
+  business?: Business;
+  /** Conversation ID (included in end chunk) */
+  conversation_id?: string;
+}
+
+// =============================================================================
+// Transaction Search Types
+// =============================================================================
+
+export interface TransactionSearchParams {
+  /** Transaction type (currently only 'delivery') */
+  transaction_type: 'delivery';
+  /** Location string */
+  location?: string;
+  /** Latitude */
+  latitude?: number;
+  /** Longitude */
+  longitude?: number;
+  /** Search term */
+  term?: string;
+  /** Categories to filter by */
+  categories?: string[];
+  /** Price levels to filter by (1-4) */
+  price?: number[];
+}
+
+export interface TransactionSearchResult {
+  businesses: Business[];
+  total: number;
+}
+
+// =============================================================================
+// Service Offerings Types
+// =============================================================================
+
+export interface ServiceOfferingsResult {
+  /** List of active service offerings */
+  active: string[];
+  /** List of eligible service offerings */
+  eligible: string[];
+}
+
+// =============================================================================
+// Engagement Metrics Types
+// =============================================================================
+
+export interface EngagementMetricsParams {
+  /** Comma-separated list of business IDs (max 50) */
+  business_ids: string;
+  /** Start date for metrics (YYYY-MM-DD) */
+  start_date?: string;
+  /** End date for metrics (YYYY-MM-DD) */
+  end_date?: string;
+}
+
+export interface BusinessEngagement {
+  business_id: string;
+  metrics: {
+    impressions?: number;
+    leads?: number;
+    calls?: number;
+    direction_requests?: number;
+    website_clicks?: number;
+    bookmarks?: number;
+    photo_views?: number;
+    [key: string]: unknown;
+  };
+}
+
+export interface EngagementMetricsResult {
+  businesses: BusinessEngagement[];
+}
+
+// =============================================================================
+// Business Insights Types
+// =============================================================================
+
+export interface BusinessInsightsParams {
+  /** Comma-separated list of business IDs */
+  business_ids: string;
+  /** Locale code */
+  locale?: string;
+}
+
+export interface BusinessInsight {
+  business_id: string;
+  insights: Record<string, unknown>;
+}
+
+export interface BusinessInsightsResult {
+  businesses: BusinessInsight[];
+}
+
+// =============================================================================
+// Food & Drinks Insights Types
+// =============================================================================
+
+export interface FoodDrinksInsightsResult {
+  business_id: string;
+  popular_dishes?: Array<{
+    name: string;
+    count: number;
+  }>;
+  popular_drinks?: Array<{
+    name: string;
+    count: number;
+  }>;
+}
+
+// =============================================================================
+// Risk Signal Insights Types
+// =============================================================================
+
+export interface RiskSignalsInsightsResult {
+  business_id: string;
+  risk_signals?: Array<{
+    signal_type: string;
+    severity: string;
+    description: string;
+  }>;
+}
+
+// =============================================================================
+// Waitlist Types
+// =============================================================================
+
+export interface WaitEstimate {
+  est_wait: number;
+  min_wait: number;
+  max_wait: number;
+  wait_range: string;
+}
+
+export interface WaitlistStatusResult {
+  business_id: string;
+  state: 'OPEN' | 'ON_MY_WAY' | 'CLOSED';
+  closed_reason: 'resto_closed' | 'remote_entry_disabled' | 'special_event' | 'no_current_wait' | 'waitlist_closed' | null;
+  wait_estimates: Record<string, WaitEstimate>;
+}
+
+export interface WaitlistInfoResult {
+  business_id: string;
+  name: string;
+  is_waitlist_enabled: boolean;
+  operating_hours?: Array<{
+    day: number;
+    start: string;
+    end: string;
+  }>;
+}
+
+export interface VisitResult {
+  visit_id: string;
+  business_id: string;
+  party_size: number;
+  status: string;
+  estimated_wait_time?: number;
+  check_in_time?: string;
+  seated_time?: string;
+  customer_name?: string;
+}
+
+export interface PartnerRestaurantsParams {
+  /** Location string */
+  location?: string;
+  /** Latitude */
+  latitude?: number;
+  /** Longitude */
+  longitude?: number;
+  /** Search radius in meters */
+  radius?: number;
+  /** Number of results to return */
+  limit?: number;
+  /** Offset for pagination */
+  offset?: number;
+}
+
+export interface PartnerRestaurant {
+  business_id: string;
+  name: string;
+  alias: string;
+  image_url?: string;
+  location: Location;
+  coordinates: Coordinates;
+  is_waitlist_enabled: boolean;
+}
+
+export interface PartnerRestaurantsResult {
+  restaurants: PartnerRestaurant[];
+  total: number;
+}
+
+// =============================================================================
+// Reservations Types
+// =============================================================================
+
+export interface ReservationOpeningsParams {
+  /** Business ID or alias */
+  business_id_or_alias: string;
+  /** Number of people (1-10) */
+  covers: number;
+  /** Date in YYYY-MM-DD format */
+  date: string;
+  /** Time in HH:MM format */
+  time: string;
+  /** Include covers range info */
+  get_covers_range?: boolean;
+}
+
+export interface ReservationTime {
+  time: string;
+  credit_card_required: boolean;
+}
+
+export interface ReservationDay {
+  date: string;
+  times: ReservationTime[];
+}
+
+export interface ReservationOpeningsResult {
+  reservation_times: ReservationDay[];
+  covers_range?: {
+    min_party_size: number;
+    max_party_size: number;
+  };
+}
+
+export interface ReservationStatusResult {
+  reservation_id: string;
+  business_id: string;
+  status: 'confirmed' | 'cancelled' | 'completed' | 'no_show';
+  covers: number;
+  date: string;
+  time: string;
+  customer_name?: string;
+  customer_phone?: string;
+  special_requests?: string;
+}
+
+// =============================================================================
+// Error Types
+// =============================================================================
+
+export interface YelpApiError {
+  error: {
+    code: string;
+    description: string;
+    field?: string;
+    instance?: string;
+  };
+}
+
+export class YelpError extends Error {
+  code: string;
+  field?: string;
+
+  constructor(error: YelpApiError['error']) {
+    super(error.description);
+    this.name = 'YelpError';
+    this.code = error.code;
+    this.field = error.field;
+  }
+}

--- a/servers/server-yelp-fusionai/tsconfig.build.json
+++ b/servers/server-yelp-fusionai/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "coverage", "**/*.test.ts", "tests/**/*"]
+}

--- a/servers/server-yelp-fusionai/tsconfig.json
+++ b/servers/server-yelp-fusionai/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "coverage", "**/*.test.ts", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary

- Adds a new MCP server wrapping the Yelp Fusion API with Streamable HTTP transport
- Implements 26 tools covering all v3 consumer-facing read-only endpoints
- Fixes accidental submodule reference for the server directory

### Tools Implemented

**Business Search**: `yelp_search`, `yelp_phone_search`, `yelp_business_match`, `yelp_business_details`

**Reviews**: `yelp_reviews`, `yelp_review_highlights`

**AI Chat**: `yelp_ai_chat`, `yelp_ai_chat_stream` (with SSE streaming)

**Events**: `yelp_events`, `yelp_event_details`, `yelp_featured_event`

**Autocomplete & Categories**: `yelp_autocomplete`, `yelp_categories`, `yelp_category_details`

**Transactions**: `yelp_delivery_search`, `yelp_service_offerings`

**Insights**: `yelp_engagement_metrics`, `yelp_business_insights`, `yelp_food_drinks_insights`, `yelp_risk_signals`

**Waitlist**: `yelp_waitlist_status`, `yelp_waitlist_info`, `yelp_visit_details`, `yelp_partner_restaurants`

**Reservations**: `yelp_reservation_openings`, `yelp_reservation_status`

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Server starts with `YELP_API_KEY` env var
- [ ] Health endpoint responds at `/health`
- [ ] MCP tools list via `/info`

🤖 Generated with [Claude Code](https://claude.ai/code)